### PR TITLE
Add ADR for patch release process as per Community Discussion #7

### DIFF
--- a/docs/adr/2021-06-01-patch-release-process.md
+++ b/docs/adr/2021-06-01-patch-release-process.md
@@ -1,0 +1,45 @@
+# Make two releases a year. One major, one patch
+
+* Status: accepted
+* Deciders: @handrews @jdesrosiers @relequestual @gregdennis @karenetheridge
+* Date: 2021-06-01
+
+Technical Story: https://github.com/json-schema-org/community/discussions/7
+
+## Context and Problem Statement
+
+JSON Schema has no formalised release process. Currently, we kind of release when we feel there's enough to bundle into a release, with a vague notion of IETF drafts expiring after 6 months.
+
+We want to have a reliable release cadence, to allow us to set pace, but also so others know what to expect.
+
+## Decision Drivers <!-- optional -->
+
+* We have occasionally found small fixes or clarifications would be helpful
+* We want to respond to feedback without having to wait a year due to slow processes
+
+## Considered Options
+
+We didn't formally consider any other options. No alternative proposals were offered.
+
+## Decision Outcome
+
+Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)].
+
+There were several agreements and comments, but no objections.
+We felt this change and formal schedule of a release process made sense over "*shrugs* whatever".
+A formal documented release schedule gives us something to aim for, and it can be revised if we feel it is not or does not work for the project.
+
+### Positive Consequences <!-- optional -->
+
+JSON Schema has a release schedule plan which people can develop and plan around.
+This should make choosing a version, and planning upgrades, something that can be done with consideration of timelines.
+
+### Negative Consequences <!-- optional -->
+
+There may be some additional pressure to create the releases to a schedule.
+
+## Links <!-- optional -->
+
+* Discussion: [Patch release process (fixes without changing meta-schema or test compliance) and branch usage](https://github.com/json-schema-org/community/discussions/7)
+* Issue: [Document the new release cycle](https://github.com/json-schema-org/community/issues/106)
+* Pull Request: pending

--- a/docs/adr/2021-06-01-patch-release-process.md
+++ b/docs/adr/2021-06-01-patch-release-process.md
@@ -31,7 +31,7 @@ A formal documented release schedule gives us something to aim for, and it can b
 ### Positive Consequences <!-- optional -->
 
 JSON Schema has a release schedule plan which people can develop and plan around.
-This should make choosing a version, and planning upgrades, something that can be done with consideration of timelines.
+This should make choosing a version and planning upgrades something that can be done with consideration of timelines.
 
 ### Negative Consequences <!-- optional -->
 

--- a/docs/adr/2021-06-01-patch-release-process.md
+++ b/docs/adr/2021-06-01-patch-release-process.md
@@ -23,7 +23,6 @@ We didn't formally consider any other options. No alternative proposals were off
 
 ## Decision Outcome
 
-Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)].
 
 There were several agreements and comments, but no objections.
 We felt this change and formal schedule of a release process made sense over "*shrugs* whatever".

--- a/docs/adr/2021-06-01-patch-release-process.md
+++ b/docs/adr/2021-06-01-patch-release-process.md
@@ -1,7 +1,7 @@
 # Make two releases a year. One major, one patch
 
 * Status: accepted
-* Deciders: @handrews @jdesrosiers @relequestual @gregdennis @karenetheridge
+* Deciders: @handrews @jdesrosiers @relequestual @gregsdennis @karenetheridge
 * Date: 2021-06-01
 
 Technical Story: https://github.com/json-schema-org/community/discussions/7


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
**GitHub Issue:** #106 

**Summary**: Adding ADR for the patch release process.
Pending documentation as per #106

Additionally seeking review from @gregsdennis and @karenetheridge.

This should not be merged until:

- [ ] Documentation of the patch release process is added 