### PR TITLE
Add documentation for topics of the slack channels

### DIFF
--- a/slack/channel-topics.json
+++ b/slack/channel-topics.json
@@ -1,5 +1,32 @@
 {
   "channels": {
-    "general": ":wave: Discuss and ask questions about all JSON Schema related things. Please see the full channel description and the @GreetBot introduction."
+    "general": ":wave: Discuss and ask questions about all JSON Schema related things. Please see the full channel description and the @GreetBot introduction.",
+    "announcements": "Announcements from the JSON Schema organisation",
+    "jp": "コミュニティの日本語を話す友人と、JSONスキーマに関連するすべての会話について話し合い、参加します。完全なチャネルの説明を参照してください。",
+    "implementers": "Development of validation libraries and other software tools. Questions about using these tools, and general schema authoring issues should go to #general",
+    "slack-bot-test": "Kindly do not start any discussions here. This is just a channel to test the slack-bot.",
+    "introductions": "Break the ice, introduce yourself to our amazing community, and connect with each other!",
+    "asyncapi": "Shared channel for JSON Schema and AsyncAPI slack servers. Ask questions, get help.",
+    "community": "Discussing our community, how it operates, and how we would like it to operate.",
+    "vocab-idl": "Discussions related to the vocabulary built by the JSON Schema community for its interface description language.",
+    "in-the-wild": "Share all and every use of JSON Schema you see in the wild. See https://json-schema.slack.com/archives/C020M2HR37G/p1620122275000700",
+    "events": "Discussions and queries related to any events related to JSON Schema community.",
+    "ghd-community": "Automated postings of created Discussions and comments from https://github.com/json-schema-org/community/discussions",
+    "vocab-forms": "JSON Schema's form generation vocabulary related discussions.",
+    "jobs": "Post job openings related to JSON Schema or APIs.",
+    "z-random": "Non-work banter and water cooler conversation. Still in bounds for our code of conduct. OK",
+    "draft-publication": "Discussions related to the drafts to be published next",
+    "tests": "Development of the official test suite",
+    "stack-overflow": "Stackoverflow questions tagged with JSON Schema. Unrelated questions will be deleted.",
+    "vocabularies": "https://github.com/json-schema-org/json-schema-vocabularies",
+    "website": "Suggestions for and development of the JSON Schema website <https://json-schema.org/>",
+    "openapi-dialect": "Discussions and queries related to OpenAPI JSON Schema dialect.",
+    "watercooler": "A communication channel for everyone who needs to chat and network but within the boundaries of our code of conduct.",
+    "vocab-databases": "Discussions and posting queries related to the JSON Schema database vocabulary.",
+    "documentation": "Discussing the documentation of JSON Schema itself",
+    "specification": "Potential changes to the specification text of JSON Schema",
+    "twitter-mentions": "This channel is only for JSON Schema's Twitter mentions. Kindly do not discuss anything here.",
+    "hyper-schema": "Discussions and queries related to vocabulary for annotating JSON documents with hyperlinks.",
+    "github": "Github stream of activity. You probably want to switch notifications to mention only mode!"
   }
 }


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
**GitHub Issue:** #180 

**Summary**: Documenting all of the slack server's channels' topics into [channel-topics.json](https://github.com/json-schema-org/community/blob/main/slack/channel-topics.json) file so that the team can keep a track of any unauthorized changes to the channels' topics.

**Do you think resolving this issue might require an [Architectural Decision Record (ADR)](https://github.com/json-schema-org/community/blob/main/CONTRIBUTING.md#key-architectural-decisions)? (significant or noteworthy)**
<!-- If the issue has the `adr-required`, this PR must include an ADR. -->
<!-- If you do not want to include an ADR, or are not sure how to make one, make sure you allow edits to this PR by maintainers. -->

No