### PR TITLE
Add a 'current-work' location to allow people to highlight current areas of focus or interest

### DIFF
--- a/current-work/README.md
+++ b/current-work/README.md
@@ -18,8 +18,8 @@ We may introduce automations to assist in this at a later point, or a medium tha
 #### How should the file be updated?
 
 Initially, it's expected that only those who are actively contributing should look at add add items to the list.
-To add items to the list, either make commits directly, or make a PR and then nudge someone to approve it.
-If you'd like permission to commit to the repo, please do ask.
+To add items to the list, either make commits directly in this repo.
+If you'd like permission to commit to the repo, please do ask on our [Slack server](https://json-schema.org/slack) in the `#community` channel.
 
 If you're adding to the list for the first time, please copy the below template, and add your GitHub username in alphabetical order.
 
@@ -42,3 +42,7 @@ OK! Great! You want [the-list.md](./the-list.md)
 ## More?
 
 @relequestual had some ideas on how automation could make this easier to use and encourage engagement, but it lead to a rabbit hole of questions and looking at docs and there wasn't any low-hanging fruit to be had. He intends to write up some suggestions on this soon.
+
+## I have a suggestion on this process...
+
+Great, let's hear it! Create a new [Discussion](https://github.com/json-schema-org/community/discussions) and let's talk.

--- a/current-work/README.md
+++ b/current-work/README.md
@@ -1,0 +1,44 @@
+# The JSON Schema Organization's areas of focus or interest
+
+## About
+### What is this space?
+
+During an [Open Community Working Meeting](https://github.com/json-schema-org/community/issues/244), it was suggested that we could have a place for the core team (and maybe active community members?) to log their current areas of focus or interest in the form of GitHub Issues, Pull Requests, and Discussions.
+
+### Why?
+
+We concluded there was a LOT of activity taking place, and it was hard to get people to focus on the "important things". It is indeed hard to focus on priority items when there are many new GitHub Issues and Discussions each week, especially for those who are community members or not working on JSON Schema full or even part time. It was suggested that by asking for one to three items of priority, we might find it easier to draw attention where we feel it is needed.
+
+### How?
+
+The process will initially be manual and require people to commit to the adjacent file which contains the list.
+The list will be used as it is found on Friday to help assist populate the following Monday's Open Community Working Meeting agenda.
+We may introduce automations to assist in this at a later point, or a medium that isn't storing data in a text file.
+
+#### How should the file be updated?
+
+Initially, only those who are actively contributing should look at add items to the list.
+To add items to the list, either make commits directly, or make a PR and then nudge someone to approve it.
+If you'd like permission to commit to the repo, please do ask.
+
+If you're adding to the list for the first time, please copy the below template, and add your GitHub username in alphabetical order.
+
+<detail>
+  <summary>Show/hide template</summary>
+
+```md
+  Link: [Link to Github Issue, Pull Request, or Discussion]
+  What?: [The most simplest basic explanation of what the thing is about. Think a single tweets length or less.]
+  Why does it matter?: [Pitch why people should care about this too. Why do you care about it?]
+  What can we do?: [What would you like us to do in relation to this thing?]
+```
+
+</detail>
+
+### Show me the details
+
+OK! Great! You want [the-list.md](./the-list.md)
+
+## More?
+
+@relequestual had some ideas on how automation could make this easier to use and encourage engagement, but it lead to a rabbit hole of questions and looking at docs and there wasn't any low-hanging fruit to be had. He intends to write up some suggestions on this soon.

--- a/current-work/README.md
+++ b/current-work/README.md
@@ -27,10 +27,10 @@ If you're adding to the list for the first time, please copy the below template,
   <summary>Show/hide template</summary>
 
 ```md
-  Link: [Link to Github Issue, Pull Request, or Discussion]
-  What?: [The most simplest basic explanation of what the thing is about. Think a single tweets length or less.]
-  Why does it matter?: [Pitch why people should care about this too. Why do you care about it?]
-  What can we do?: [What would you like us to do in relation to this thing?]
+  **Link:** [Link to Github Issue, Pull Request, or Discussion]<br/>
+  **What?:** [The most simplest basic explanation of what the thing is about. Think a single tweets length or less.]<br/>
+  **Why does it matter?:** [Pitch why people should care about this too. Why do you care about it?]<br/>
+  **What can we do?:** [What would you like us to do in relation to this thing?]<br/>
 ```
 
 </detail>

--- a/current-work/README.md
+++ b/current-work/README.md
@@ -17,7 +17,7 @@ We may introduce automations to assist in this at a later point, or a medium tha
 
 #### How should the file be updated?
 
-Initially, only those who are actively contributing should look at add items to the list.
+Initially, it's expected that only those who are actively contributing should look at add add items to the list.
 To add items to the list, either make commits directly, or make a PR and then nudge someone to approve it.
 If you'd like permission to commit to the repo, please do ask.
 

--- a/current-work/README.md
+++ b/current-work/README.md
@@ -17,7 +17,7 @@ We may introduce automations to assist in this at a later point, or a medium tha
 
 #### How should the file be updated?
 
-Initially, it's expected that only those who are actively contributing should look at add add items to the list.
+Initially, it's expected that only those who are actively contributing should look at or add items to the list.
 To add items to the list, either make commits directly in this repo.
 If you'd like permission to commit to the repo, please do ask on our [Slack server](https://json-schema.org/slack) in the `#community` channel.
 

--- a/current-work/README.md
+++ b/current-work/README.md
@@ -3,11 +3,11 @@
 ## About
 ### What is this space?
 
-During an [Open Community Working Meeting](https://github.com/json-schema-org/community/issues/244), it was suggested that we could have a place for the core team (and maybe active community members?) to log their current areas of focus or interest in the form of GitHub Issues, Pull Requests, and Discussions.
+During an [Open Community Working Meeting](https://github.com/json-schema-org/community/issues/244), it was suggested that we could have a place for the core team (and maybe active community members?) to indicate which areas of their work most require attention from the core team members, in the form of GitHub Issues, Pull Requests, and Discussions.
 
 ### Why?
 
-We concluded there was a LOT of activity taking place, and it was hard to get people to focus on the "important things". It is indeed hard to focus on priority items when there are many new GitHub Issues and Discussions each week, especially for those who are community members or not working on JSON Schema full or even part time. It was suggested that by asking for one to three items of priority, we might find it easier to draw attention where we feel it is needed.
+We concluded there was a LOT of activity taking place, and it was hard to get people to respond to the most immediately important things. It is indeed hard to focus on priority items when there are many new GitHub Issues and Discussions each week, especially for those who are community members or not working on JSON Schema full or even part time. It was suggested that by asking for one to three items of priority, we might find it easier to draw attention where we feel it is needed.
 
 ### How?
 
@@ -18,7 +18,7 @@ We may introduce automations to assist in this at a later point, or a medium tha
 #### How should the file be updated?
 
 Initially, it's expected that only those who are actively contributing should look at or add items to the list.
-To add items to the list, either make commits directly in this repo.
+To add items to the list, make commits directly in this repo.
 If you'd like permission to commit to the repo, please do ask on our [Slack server](https://json-schema.org/slack) in the `#community` channel.
 
 If you're adding to the list for the first time, please copy the below template, and add your GitHub username in alphabetical order.

--- a/current-work/README.md
+++ b/current-work/README.md
@@ -23,7 +23,7 @@ If you'd like permission to commit to the repo, please do ask.
 
 If you're adding to the list for the first time, please copy the below template, and add your GitHub username in alphabetical order.
 
-<detail>
+<details>
   <summary>Show/hide template</summary>
 
 ```md
@@ -33,7 +33,7 @@ If you're adding to the list for the first time, please copy the below template,
   **What can we do?:** [What would you like us to do in relation to this thing?]<br/>
 ```
 
-</detail>
+</details>
 
 ### Show me the details
 

--- a/current-work/the-list.md
+++ b/current-work/the-list.md
@@ -8,7 +8,7 @@ Please see the adjacent [README](./README.md).
 
 ### @relequestual
 
-Link : https://github.com/json-schema-org/community/pull/250
-What? : Creating this file and the guide on how to use it
-Why does it matter? : People feel it would be easier to see areas of focus if we highlight them
-What can people do? : Review and approve this PR! =]
+**Link:** https://github.com/json-schema-org/community/pull/250<br/>
+**What?:** Creating this file and the guide on how to use it<br/>
+**Why does it matter?:** People feel it would be easier to see areas of focus if we highlight them<br/>
+**What can people do?:** Review and approve this PR! =]<br/>

--- a/current-work/the-list.md
+++ b/current-work/the-list.md
@@ -8,7 +8,7 @@ Please see the adjacent [README](./README.md).
 
 ### @relequestual
 
-Link :
-What? :
-Why does it matter? :
-What can people do? :
+Link : https://github.com/json-schema-org/community/pull/250
+What? : Creating this file and the guide on how to use it
+Why does it matter? : People feel it would be easier to see areas of focus if we highlight them
+What can people do? : Review and approve this PR! =]

--- a/current-work/the-list.md
+++ b/current-work/the-list.md
@@ -1,0 +1,14 @@
+# The JSON Schema Organization's areas of focus or interest
+
+## What is this document?
+
+Please see the adjacent [README](./README.md).
+
+## The lists of things
+
+### @relequestual
+
+Link :
+What? :
+Why does it matter? :
+What can people do? :


### PR DESCRIPTION
Resolves https://github.com/json-schema-org/community/issues/249

<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
**GitHub Issue:** https://github.com/json-schema-org/community/issues/249

**Summary**: Add two files, one which explains the purpose of logging current areas of interest, and another to contain them.

**Do you think resolving this issue might require an [Architectural Decision Record (ADR)](https://github.com/json-schema-org/community/blob/main/CONTRIBUTING.md#key-architectural-decisions)? (significant or noteworthy)**
<!-- If the issue has the `adr-required`, this PR must include an ADR. -->
<!-- If you do not want to include an ADR, or are not sure how to make one, make sure you allow edits to this PR by maintainers. -->
No
It's a new thing we are testing which is open to change based on feedback.