### PR TITLE
Add Personal User Manuals including template and first manual

### DIFF
--- a/docs/personal-manuals/README.md
+++ b/docs/personal-manuals/README.md
@@ -1,0 +1,19 @@
+# Personal Manuals
+
+We have a dispersed team and community, spread across many physical locations, living with different cultures. We are not diverse as we could be, but diverse enough for differences to become apparent.
+
+Creating personal "User Manuals" allows us to help each other understand how we can best work with each other.
+
+In the spirit of trying to work well with each other, those who are part of a team or who are regularly active in the community are **invited** to write a Personal User Manual. (It's by no means a requirement. If you have concerns, try to write something that's as minimal as you feel is OK yet still provides value to your colleagues and collaborators.)
+
+The manuals are found in the `manuals` folder.
+The name of the file is the individuals GitHub username, optionally followed by double dash `--` and the users preferred name (either short or long). (GitHub usernames cannot have double hyphens, or begin or end with a hyphen.)
+
+There is a template found in `template.md` which it is recommended you use.
+
+These manuals should be used as an opportunity to understand each other better. You should not expect someone to have read and remembered all the details in your manual.
+
+This page will also list those files in alphabetical order below.
+(Please update this manually for now)
+
+## Personal User Manual listing

--- a/docs/personal-manuals/README.md
+++ b/docs/personal-manuals/README.md
@@ -17,3 +17,5 @@ This page will also list those files in alphabetical order below.
 (Please update this manually for now)
 
 ## Personal User Manual listing
+
+- [@Relequestual / Ben Hutton's Personal User Manual](relequestual--ben-hutton.md)

--- a/docs/personal-manuals/manuals/relequestual--ben-hutton.md
+++ b/docs/personal-manuals/manuals/relequestual--ben-hutton.md
@@ -1,0 +1,61 @@
+# @Relequestual / Ben Hutton's Personal User Manual
+
+## Working Patterns
+
+My normal working hours are 08:00 to 16:00 GMT/BST.
+I prefer to keep to these times to allow for family time.
+There are a few regular meetings which fall outside of these times as exceptions. I roughly use the time in lieu.
+
+I use a tool to automatically scheduled my work, and allow for two slots during the day where I'll check emails.
+I may or may not check Slack outside of those hours.
+I tend to work on a "Manager's Schedule" as opposed to a "Maker's Schedule" (See [Schedules](http://www.paulgraham.com/makersschedule.html)), however that may change.
+
+My Slack status usually shows what sort of work I'm doing.
+When in deep focused work and some other types of work, notifications are disabled.
+
+I may send you slack messages at any time, but with no expectation of replying immediately.
+Feel free to send me slack messages whenever, but do not expect an immediate reply. I might see your message in an evening and set a Slack reminder to reply when I'm back at my desk the next day. If it prompts a longer reply, you may be waiting another day.
+(I do not mind, and even invite, nagging. I'm pretty forgetful, hence the use of Slack reminders.)
+
+## Requirements
+
+I work best when items of work are scheduled. I'm not likely to want ad-hoc immediate calls/meetings.
+I invite people to book a slot for a call where the discussion isn't urgent.
+I prefer to have my calendar filled rather than empty. Using the calendar booking system will allow the booking of slots which appear full on my calendar; some types of work will move out the way if the deadline is still feasible.
+
+I declared GitHub notification bankruptcy. Mentioning me on GitHub is not going to get my attention. (I MAY pick it up if it's within the JSON Schema org, but by no means guaranteed). Your best bet for signposting me to activity on GitHub is to DM me on Slack with your specific ask.
+I make extensive use of Slack reminders, and I do welcome repeated nagging if I fail to do something in a reasonable time frame.
+
+If you have a deadline for an ask, please be upfront about it. As I like to have my calendar full of pre-scheduled work, I'll likely already have my week planned, with a good notion of what I'll be doing the following week. Ideally, I'd like 1-2 weeks lead time on absolute hard deadlines. Of course, I can be flexible, but it should be an exception as opposed to a norm.
+
+## Feedback
+
+The best way to give me feedback is to be very candid. I'm really keen to learn from others, and I'm extremely unlikely to be offended.
+I'll take any and all feedback I can get. While I would always prefer constructive feedback and reasons as to why you have a specific opinion, I won't object to a gut feeling.
+I'll critically evaluate feedback to determine it's value, and act accordingly. (Not acting on feedback is not necessarily an indication of it's perceived value.)
+
+## Stress
+
+It generally takes a lot to make me stressed.
+I'm most likely to feel stressed when I feel like I haven't accomplished anything useful or time has been wasted. I'll take small wins.
+
+It helps if I reframe "wasted time" as lessons learnt. I'll take learning as a win.
+It helps if my calendar schedule is full AND I can stick to the schedule.
+
+If you see my schedule looking empty or not full, that's a potentially a bad sign, but maybe not.
+I'm more apathetic when stressed, so may be slower to respond.
+(Although, I still encourage nagging. Specifically nagging which suggests adding a task which will auto add to my calendar.)
+
+## Non-work
+
+I have a broad taste in music, and enjoy both video games and board games.
+Family with young kids keeps me pretty busy.
+
+I'm mostly into sim or colony management type video games. I don't play online games.
+I enjoy a range of (modern) board games, mostly strategy, and not party games. We're not talking Monopoly here.
+My all time favourite artist is Bonobo.
+
+## Anything else?
+
+I'm a coffee snob but I generally only have one coffee a day.
+I prefer a Long Black over an Americano.

--- a/docs/personal-manuals/manuals/relequestual--ben-hutton.md
+++ b/docs/personal-manuals/manuals/relequestual--ben-hutton.md
@@ -42,7 +42,7 @@ I'm most likely to feel stressed when I feel like I haven't accomplished anythin
 It helps if I reframe "wasted time" as lessons learnt. I'll take learning as a win.
 It helps if my calendar schedule is full AND I can stick to the schedule.
 
-If you see my schedule looking empty or not full, that's a potentially a bad sign, but maybe not.
+If you see my schedule looking empty or not full, that's potentially a bad sign, but maybe not.
 I'm more apathetic when stressed, so may be slower to respond.
 (Although, I still encourage nagging. Specifically nagging which suggests adding a task which will auto add to my calendar.)
 

--- a/docs/personal-manuals/template.md
+++ b/docs/personal-manuals/template.md
@@ -1,0 +1,23 @@
+# [Name]'s Personal User Manual
+
+## Working Patterns
+
+My best working patterns look like...
+
+## Requirements
+
+My absolute requirements to do great work are...
+
+## Feedback
+
+The best way to give me feedback is...
+
+## Stress
+
+When I'm dealing with stress, I...
+
+## Non-work
+
+Beyond work, I'm really passionate about...
+
+## Anything else?


### PR DESCRIPTION
In order to aid getting to know each other and form a better team, I've created a section for "personal user manuals".

The aim is to allow people to share information and preferences about themselves to help us understand how to best work with each other and reduce the potential for friction.

There's a template, but I've included my user manual as a starting point.