### PR TITLE
Update the `other channels` file to match current state, then propose adding #contribute

### DIFF
--- a/slack/other channels
+++ b/slack/other channels
@@ -1,13 +1,16 @@
-Here are some of our other channels and why you might want to join them.
+Here are some of our other channels and why you might want to join them:
 
-#implementers - Those implementing the specification and questions about implementation details
-#specification - Potential changes to the JSON Schema specification
-#tests - Development of the official test suite
-#community - Development of the JSON Schema community and organization
-#in-the-wild - Share references to observed uses of JSON Schemas in other applications or projects, and any JSON Schema related content
+* #implementers - Those implementing the specification and questions about implementation details
+* #specification - Potential changes to the JSON Schema specification
+* #tests - Development of the official test suite
+* #documentation - Discuss, brainstorm and recommend documentation on json-schema.org or elsewhere
 
-#watercooler - Space to chat about anything off topic or just catch up
-#z-random - Anything that's really far off topic
+* #announcements - Announcements from the JSON Schema organisation
+* #community-mgmt - Discussing the community itself, how it operates, and how we would like it to operate.
 
-#stack-overflow - Automated feed of StackOverflow questions tagged with JSON Schema
-#github - Automated feed of Github Issues and Pull Requests
+* #in-the-wild - Share references to observed uses of JSON Schemas in other applications or projects, and any JSON Schema related content
+* #stack-overflow - Automated feed of StackOverflow questions tagged with JSON Schema
+* #github - Automated feed of Github Issues and Pull Requests
+
+* #watercooler - Space to chat about anything off topic or just catch up
+* #z-random - Anything that's really far off topic

--- a/slack/other channels
+++ b/slack/other channels
@@ -1,5 +1,6 @@
 Here are some of our other channels and why you might want to join them:
 
+* #contribute - A channel for discussing contributions to JSON Schema itself, or for getting started doing so
 * #implementers - Those implementing the specification and questions about implementation details
 * #specification - Potential changes to the JSON Schema specification
 * #tests - Development of the official test suite

--- a/slack/other channels
+++ b/slack/other channels
@@ -1,10 +1,9 @@
 Here are some of our other channels and why you might want to join them:
 
-* #contribute - A channel for discussing contributions to JSON Schema itself, or for getting started doing so
+* #contribute - A channel for discussing or getting help with contributions to JSON Schema itself (its tooling, website, documentation or beyond)
 * #implementers - Those implementing the specification and questions about implementation details
 * #specification - Potential changes to the JSON Schema specification
 * #tests - Development of the official test suite
-* #documentation - Discuss, brainstorm and recommend documentation on json-schema.org or elsewhere
 
 * #announcements - Announcements from the JSON Schema organisation
 * #community-mgmt - Discussing the community itself, how it operates, and how we would like it to operate.


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
**GitHub Issue:** # / NA

**Summary**: This small PR contains 3 commits:

* One updating the file to match today's channels, which should be uncontroversial
* One proposing adding a `#contribute` channel, whose purpose is elaborated on below
* One proposing folding the `#documentation` and `#website` channels into `#contribute`

The latter two commits are independent from the first, so if we decide not to do them (or one of them) we can obviously.

The purpose of the `#contribute` channel would be:

* as a starting point for new contributors looking for things to work on
* as a place to discuss general contributions that are in-progress (e.g. someone needs help on a PR or something) for topics that don't already fit in `#specification`

Also "implicit" in this PR is one *non-commit-expressed* proposal:

**Close / archive the `#collaborators` channel**

which is (you'll note) absent in the `other channels` changes I made.

The reasoning for doing so is that lots of what people put in there is "development in secret" -- wherein discussions happen which can perfectly well happen in public, they have to do with development of JSON Schema itself and are in no way private -- for which the only sorts of discussions I propose are truly considered private are ones which in some way have to do with CoC violations or other specific categories (which we can probably reflect on if really needed). Those discussions can indeed continue to happen somewhere else in private.

This PR does *not* propose also removing `#specification` or `#tests` in favor of folding those into `#contribute`, though of course we could if there's support for doing so eventually (it seems likely that those are fine as-is to me I suppose, as to me the reasons to do this center around channel volume and whether each channel has a distinct audience which I think those may, so I wouldn't necessarily be pushing for doing so myself).

Obviously merging this PR will not enact the changes, so this is simply a proposed structure which we'd then make real if accepted (probably by simply renaming one of `#documentation` or `#website` to contribute, updating its topic, then archiving the other). I'm tagging a few reviewers just so you see this, if you don't care, obviously feel free not to chime in :)

**Do you think resolving this issue might require an [Architectural Decision Record (ADR)](https://github.com/json-schema-org/community/blob/main/CONTRIBUTING.md#key-architectural-decisions)? (significant or noteworthy)**
<!-- If the issue has the `adr-required`, this PR must include an ADR. -->
<!-- If you do not want to include an ADR, or are not sure how to make one, make sure you allow edits to this PR by maintainers. -->

No