### PR TITLE
Add tsc-discussion Slack channel to list of channels

### DIFF
--- a/slack/other channels
+++ b/slack/other channels
@@ -8,6 +8,7 @@ Here are some of our other channels and why you might want to join them:
 * #announcements - Announcements from the JSON Schema organisation
 * #community-announcements - To share updates about any JSON Schema related Project, Tool or Event
 * #community-mgmt - Discussing the community itself, how it operates, and how we would like it to operate.
+* #tsc-discussion - A public place for the Technical Steering Committee to discuss current activities.
 
 * #in-the-wild - Share references to observed uses of JSON Schemas in other applications or projects, and any JSON Schema related content
 * #stack-overflow - Automated feed of StackOverflow questions tagged with JSON Schema


### PR DESCRIPTION
Resolves https://github.com/json-schema-org/community/issues/414

Add `tsc-discussion` channel to Slack.
Approving this PR, as per #414, implies approval of creating a private `private-tsc-discussion` channel, and archiving the private `collaborators` channel.
