### PR TITLE
Update ocwm-creator.yml to run in node 18

### DIFF
--- a/.github/workflows/ocwm-creator.yml
+++ b/.github/workflows/ocwm-creator.yml
@@ -13,6 +13,10 @@ jobs:
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v2
+    - name: Set up Node 18
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/ocwm-creator.yml
+++ b/.github/workflows/ocwm-creator.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v2
     - name: Set up Node 18
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v2
       with:
         node-version: 18
     - name: Set up Python
@@ -37,7 +37,7 @@ jobs:
         token: ${{ secrets.AUTH_TOKEN }}
 
     - name: Install dependencies
-      run: npm install @octokit/core
+      run: npm install @octokit/core axios
 
     - name: Update Issue Body
       uses: actions/github-script@v6
@@ -45,8 +45,36 @@ jobs:
         MY_TOKEN: ${{ secrets.AUTH_TOKEN }}
       with:
         script: |
-          const octokit = require('@octokit/core').Octokit;  
-          const mygithub = new octokit({ auth: process.env.MY_TOKEN });
+          const { Octokit } = require('@octokit/core');
+          const axios = require('axios').default;
+
+          const customFetch = async (url, options) => {
+            const res = await axios({
+              url,
+              method: options.method || 'GET',
+              headers: {
+                ...options.headers,
+                authorization: `token ${process.env.MY_TOKEN}`,
+              },
+              data: options.body,
+            });
+
+            return {
+              ok: res.status >= 200 && res.status <= 299,
+              status: res.status,
+              statusText: res.statusText,
+              json: () => res.data,
+              text: () => res.data,
+              headers: res.headers,
+            };
+          };
+
+          const mygithub = new Octokit({
+            request: {
+              fetch: customFetch,
+            },
+          });
+
           const ocwmnumber = ${{ steps.create-issue.outputs.issue-number }};
 
           const { data: ocwmissue } = await mygithub.request(`GET /repos/${context.repo.owner}/${context.repo.repo}/issues/${ ocwmnumber }`, {


### PR DESCRIPTION
When running this action we are getting this error:

Unhandled error: Error: fetch is not set. Please pass a fetch implementation as new Octokit({ request: { fetch }}). Learn more at https://github.com/octokit/octokit.js/#fetch-missing 

To avoid it we setting up the action to run in node 18.
