### PR TITLE
Adding Manfred as JSON Schema Adopter

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -38,15 +38,15 @@ By supporting JSON Schema with a case study, you are documenting its success and
 
 | Organization | Contact | Description of Use / Reference |
 | --- | --- | --- |
-| GitHub | [Rachael Sewell](https://www.linkedin.com/in/rachaelsewell/)<br/>[Robert Sese](https://www.linkedin.com/in/rsese/) | [Github JSON Schema case study](https://json-schema.org/blog/posts/github-case-study) |
-| Cookpad | [Kenshi Shiode](https://www.linkedin.com/in/kenshi-shiode-b65922212/) | [Cookpad JSON Schema case study](https://json-schema.org/blog/posts/cookpad-case-study-en) |
-| Tyler Technology | [Andres Moreno](https://www.linkedin.com/in/andmoredev/) | [Tyler Technology JSON Schema case study](https://json-schema.org/blog/posts/tyler-technologies-case-study) |
-| W3C Web of Things | [Ege Korkan](https://www.linkedin.com/in/ege-korkan/) | [W3C Web of Things JSON Schema case study](https://json-schema.org/blog/posts/w3c-wot-case-study) |
-| Remote | [Sandrina Pereira](https://www.linkedin.com/in/sandrina-p/) | [Remote JSON Schema case study](https://json-schema.org/blog/posts/remote-case-study) |
-| Postman | [Juan Cruz Viotti](https://www.linkedin.com/in/jviotti/) | [Postman JSON Schema case study](https://json-schema.org/blog/posts/postman-case-study) |
-| OpenMetadata | [Suresh Srinivas](https://www.linkedin.com/in/sureshsri/) | [OpenMetadata - JSON Schema in production episode](https://youtu.be/ZrVTZwmTR3k) |
-| Wundergraph | [Jens Neuse](https://www.linkedin.com/in/jens-neuse-706673195/) | [Wundergraph - JSON Schema in production episode](https://youtu.be/_TCU6da0GA8) |
-| Zapier | [David Brownman](https://www.linkedin.com/in/xavdid/) | [Zapier - JSON Schema in production episode](https://youtu.be/yDL98sd4KVE) |
-| Microsoft | [Mads Kristensen](https://www.linkedin.com/in/madskvistkristensen/) | [Microsoft - JSON Schema in production episode](https://youtu.be/-yYTxLZZk58) |
-| F5 | [Kin Lane](https://www.linkedin.com/in/kinlane/) | [F5 - JSON Schema in production episode](https://youtu.be/pibZF049zqE) |
+| [GitHub](https://github.com/) | [Rachael Sewell](https://www.linkedin.com/in/rachaelsewell/)<br/>[Robert Sese](https://www.linkedin.com/in/rsese/) | [Github JSON Schema case study](https://json-schema.org/blog/posts/github-case-study) |
+| [Cookpad](https://cookpad.com/) | [Kenshi Shiode](https://www.linkedin.com/in/kenshi-shiode-b65922212/) | [Cookpad JSON Schema case study](https://json-schema.org/blog/posts/cookpad-case-study-en) |
+| [Tyler Technology](https://www.tylertech.com/) | [Andres Moreno](https://www.linkedin.com/in/andmoredev/) | [Tyler Technology JSON Schema case study](https://json-schema.org/blog/posts/tyler-technologies-case-study) |
+| [W3C Web of Things](https://www.w3.org/WoT/) | [Ege Korkan](https://www.linkedin.com/in/ege-korkan/) | [W3C Web of Things JSON Schema case study](https://json-schema.org/blog/posts/w3c-wot-case-study) |
+| [Remote](https://remote.com/) | [Sandrina Pereira](https://www.linkedin.com/in/sandrina-p/) | [Remote JSON Schema case study](https://json-schema.org/blog/posts/remote-case-study) |
+| [Postman](https://www.postman.com/) | [Juan Cruz Viotti](https://www.linkedin.com/in/jviotti/) | [Postman JSON Schema case study](https://json-schema.org/blog/posts/postman-case-study) |
+| [OpenMetadata](https://open-metadata.org/) | [Suresh Srinivas](https://www.linkedin.com/in/sureshsri/) | [OpenMetadata - JSON Schema in production episode](https://youtu.be/ZrVTZwmTR3k) |
+| [Wundergraph](https://wundergraph.com/) | [Jens Neuse](https://www.linkedin.com/in/jens-neuse-706673195/) | [Wundergraph - JSON Schema in production episode](https://youtu.be/_TCU6da0GA8) |
+| [Zapier](https://zapier.com/) | [David Brownman](https://www.linkedin.com/in/xavdid/) | [Zapier - JSON Schema in production episode](https://youtu.be/yDL98sd4KVE) |
+| [Microsoft](https://www.microsoft.com/) | [Mads Kristensen](https://www.linkedin.com/in/madskvistkristensen/) | [Microsoft - JSON Schema in production episode](https://youtu.be/-yYTxLZZk58) |
+| [F5](https://www.f5.com/) | [Kin Lane](https://www.linkedin.com/in/kinlane/) | [F5 - JSON Schema in production episode](https://youtu.be/pibZF049zqE) |
 | Zones | [Chuck Reeves](https://www.linkedin.com/in/charles-reeves-156953284/) | [Zones - JSON Schema in production episode](https://youtu.be/fkziMQD7pqQ) |

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -50,3 +50,4 @@ By supporting JSON Schema with a case study, you are documenting its success and
 | [Microsoft](https://www.microsoft.com/) | [Mads Kristensen](https://www.linkedin.com/in/madskvistkristensen/) | [Microsoft - JSON Schema in production episode](https://youtu.be/-yYTxLZZk58) |
 | [F5](https://www.f5.com/) | [Kin Lane](https://www.linkedin.com/in/kinlane/) | [F5 - JSON Schema in production episode](https://youtu.be/pibZF049zqE) |
 | Zones | [Chuck Reeves](https://www.linkedin.com/in/charles-reeves-156953284/) | [Zones - JSON Schema in production episode](https://youtu.be/fkziMQD7pqQ) |
+| [Manfred](https://www.getmanfred.com/) | [David Bonilla](https://www.linkedin.com/in/dbonillaf/) | [The MAC is a standard open source format to define and share CVs](https://github.com/getmanfred/mac) |

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -50,4 +50,4 @@ By supporting JSON Schema with a case study, you are documenting its success and
 | [Microsoft](https://www.microsoft.com/) | [Mads Kristensen](https://www.linkedin.com/in/madskvistkristensen/) | [Microsoft - JSON Schema in production episode](https://youtu.be/-yYTxLZZk58) |
 | [F5](https://www.f5.com/) | [Kin Lane](https://www.linkedin.com/in/kinlane/) | [F5 - JSON Schema in production episode](https://youtu.be/pibZF049zqE) |
 | Zones | [Chuck Reeves](https://www.linkedin.com/in/charles-reeves-156953284/) | [Zones - JSON Schema in production episode](https://youtu.be/fkziMQD7pqQ) |
-| [Manfred](https://www.getmanfred.com/) | [David Bonilla](https://www.linkedin.com/in/dbonillaf/) | [The MAC is a standard open source format to define and share CVs](https://github.com/getmanfred/mac) |
+| [Manfred](https://www.getmanfred.com/) | [David Bonilla](https://www.linkedin.com/in/dbonillaf/) | [The MAC is a standard open source format created by Manfred to define and share CVs](https://github.com/getmanfred/mac) |

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -50,4 +50,5 @@ By supporting JSON Schema with a case study, you are documenting its success and
 | [Microsoft](https://www.microsoft.com/) | [Mads Kristensen](https://www.linkedin.com/in/madskvistkristensen/) | [Microsoft - JSON Schema in production episode](https://youtu.be/-yYTxLZZk58) |
 | [F5](https://www.f5.com/) | [Kin Lane](https://www.linkedin.com/in/kinlane/) | [F5 - JSON Schema in production episode](https://youtu.be/pibZF049zqE) |
 | Zones | [Chuck Reeves](https://www.linkedin.com/in/charles-reeves-156953284/) | [Zones - JSON Schema in production episode](https://youtu.be/fkziMQD7pqQ) |
+| [Automatic Data Processing (ADP)](https://www.adp.com/) | [Jeremy Fiel](mailto:jeremy.fiel@adp.com?subject=I%20love%20JSON%20Schema%20too!) | [ADP Developer Resources](https://developers.adp.com/welcome) |
 | [Manfred](https://www.getmanfred.com/) | [David Bonilla](https://www.linkedin.com/in/dbonillaf/) | [The MAC is a standard open source format created by Manfred to define and share CVs](https://github.com/getmanfred/mac) |

--- a/slack/channel-topics.json
+++ b/slack/channel-topics.json
@@ -12,6 +12,7 @@
     "github": "Github stream of activity. You probably want to switch notifications to mention only mode!",
     "hyper-schema": "Discussions and queries related to vocabulary for annotating JSON documents with hyperlinks.",
     "implementers": "Development of validation libraries and other software tools. Questions about using these tools, and general schema authoring issues should go to #general",
+    "adopters": "Discussions and queries related the JSON Schema Adopters and Case Studies",
     "in-the-wild": "Share all and every use of JSON Schema you see in the wild. See https://json-schema.slack.com/archives/C020M2HR37G/p1620122275000700",
     "introductions": "Break the ice, introduce yourself to our amazing community, and connect with each other!",
     "jobs": "Post job openings related to JSON Schema or APIs.",


### PR DESCRIPTION
**Summary**:
Adding Manfred as JSON Schema Adopter.

**Do you think resolving this issue might require an [Architectural Decision Record (ADR)](https://github.com/json-schema-org/community/blob/main/CONTRIBUTING.md#key-architectural-decisions)? (significant or noteworthy)**
<!-- If the issue has the `adr-required`, this PR must include an ADR. -->
<!-- If you do not want to include an ADR, or are not sure how to make one, make sure you allow edits to this PR by maintainers. -->

No
