### PR TITLE
New action to send slack reminders the same day of the OCWM

### DIFF
--- a/.github/workflows/ocwm-reminders.yml
+++ b/.github/workflows/ocwm-reminders.yml
@@ -1,0 +1,63 @@
+name: Send reminders to join the OCWM the same day
+
+on:
+  schedule:
+    - cron: '0 20 * * 1'  # Runs every Monday at 15:00
+
+  repository_dispatch:
+    types: ocwm-reminders
+
+jobs:
+  ocwm-reminders:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+    - name: Set up Node 20
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Install dependencies
+      run: npm install @octokit/core 
+
+    - name: Send reminders
+      uses: actions/github-script@v7
+      env:
+        MY_TOKEN: ${{ secrets.AUTH_TOKEN }}
+        OWNER: ${{ vars.ORGANISATION }}
+        REPO: 'community'
+        OCWM_LABEL: ${{ vars.OCWM_LABEL }}
+        SLACK_WEBHOOK: ${{ vars.SLACK_WEBHOOK_REMINDER }}
+      with:
+        script: |
+        
+          const octokit = require('@octokit/core').Octokit;
+          const mygithub = new octokit({
+            request: { fetch: fetch,},
+            auth: process.env.MY_TOKEN
+          });
+
+          let targetLabel = encodeURIComponent(process.env.OCWM_LABEL);
+
+          const { data: workMeetings } = await mygithub.request(`GET /repos/${process.env.OWNER}/${process.env.REPO}/issues?labels=${targetLabel}&per_page=1`, {
+          })
+
+          const issueNumber = workMeetings[0].number
+          const newTitle = workMeetings[0].title;
+          const issueDate = newTitle.replace(/Open Community Working Meeting /g, "");
+          
+          // Notify Slack
+          const SLACK_WEBHOOK_URL = process.env.SLACK_WEBHOOK;
+          const SLACK_MESSAGE = `{
+            "issue": "https://github.com/${process.env.OWNER}/${process.env.REPO}/issues/${issueNumber}",
+            "date": "${issueDate}"
+          }`;
+
+          await fetch(SLACK_WEBHOOK_URL, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: SLACK_MESSAGE,
+          });


### PR DESCRIPTION
New action to send slack reminders the same day of the OCWM

**Summary**: This GA sends slack reminders to join the OCWM the same day of the meeting.

**Do you think resolving this issue might require an [Architectural Decision Record (ADR)](https://github.com/json-schema-org/community/blob/main/CONTRIBUTING.md#key-architectural-decisions)? (significant or noteworthy)**
<!-- If the issue has the `adr-required`, this PR must include an ADR. -->
<!-- If you do not want to include an ADR, or are not sure how to make one, make sure you allow edits to this PR by maintainers. -->

No