### PR TITLE
Change cron instruction to run at 15:00 instead of 20:00

### DIFF
--- a/.github/workflows/ocwm-reminders.yml
+++ b/.github/workflows/ocwm-reminders.yml
@@ -2,7 +2,7 @@ name: Send reminders to join the OCWM the same day
 
 on:
   schedule:
-    - cron: '0 20 * * 1'  # Runs every Monday at 15:00
+    - cron: '0 15 * * 1'  # Runs every Monday at 15:00
 
   repository_dispatch:
     types: ocwm-reminders


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
**GitHub Issue:** # / NA

**Summary**: Update the action that sends the OCWM reminders to run at 15:00 instead of 20:00.

**Do you think resolving this issue might require an [Architectural Decision Record (ADR)](https://github.com/json-schema-org/community/blob/main/CONTRIBUTING.md#key-architectural-decisions)? (significant or noteworthy)**
<!-- If the issue has the `adr-required`, this PR must include an ADR. -->
<!-- If you do not want to include an ADR, or are not sure how to make one, make sure you allow edits to this PR by maintainers. -->

No