### PR TITLE
ci: Add functionality to remove 'agenda' label from added items

### DIFF
--- a/.github/workflows/ocwm-issue-collector.yml
+++ b/.github/workflows/ocwm-issue-collector.yml
@@ -114,7 +114,7 @@ jobs:
                     body = JSON.parse(json_text);
                     changesFlag = true;
                     // Remove the 'agenda' label from the added discussion
-                    await mygithub.request(`DELETE /repos/${process.env.OWNER}/${repositories[r]}/discussions/${discussions[i].node.id}/labels/${appendLabel}`);
+                    await mygithub.request(`DELETE /repos/${process.env.OWNER}/${repositories[r]}/discussions/${discussions[i].number}/labels/${appendLabel}`);
                   }
                 }
 

--- a/.github/workflows/ocwm-issue-collector.yml
+++ b/.github/workflows/ocwm-issue-collector.yml
@@ -97,6 +97,8 @@ jobs:
                         let json_text = JSON.stringify(body.substring(0, startIndex - 1) + `\n| ${url} - ${title} | ${author} |\r\n` + body.substring(startIndex, body.length));
                         body = JSON.parse(json_text);
                         changesFlag = true;
+                        // Remove the 'agenda' label from the added issue
+                        await mygithub.request(`DELETE /repos/${process.env.OWNER}/${repositories[r]}/issues/${items2add[i].number}/labels/${appendLabel}`);
                     }
                 }
 
@@ -111,6 +113,8 @@ jobs:
                     let json_text = JSON.stringify(body.substring(0, startIndex - 1) + `\n| ${url} - ${title} | ${author} |\r\n` + body.substring(startIndex, body.length));
                     body = JSON.parse(json_text);
                     changesFlag = true;
+                    // Remove the 'agenda' label from the added discussion
+                    await mygithub.request(`DELETE /repos/${process.env.OWNER}/${repositories[r]}/discussions/${discussions[i].node.id}/labels/${appendLabel}`);
                   }
                 }
 


### PR DESCRIPTION
**GitHub Issue:** #595 
Fixes #595 

**Summary**:
It enhances the existing functionality of the OCWM issue collector workflow by adding the ability to remove the 'agenda' label from items (both issues and discussions) once they have been successfully added to the agenda


**Do you think resolving this issue might require an [Architectural Decision Record (ADR)](https://github.com/json-schema-org/community/blob/main/CONTRIBUTING.md#key-architectural-decisions)? (significant or noteworthy)**
<!-- If the issue has the `adr-required`, this PR must include an ADR. -->
<!-- If you do not want to include an ADR, or are not sure how to make one, make sure you allow edits to this PR by maintainers. -->

No
[JUSTIFICATION]