### PR TITLE
Fixes Bug -  Action to send Community Meeting reminders failed

### DIFF
--- a/.github/workflows/ocwm-reminders.yml
+++ b/.github/workflows/ocwm-reminders.yml
@@ -19,7 +19,7 @@ jobs:
         node-version: '20'
 
     - name: Install dependencies
-      run: npm install @octokit/core 
+      run: npm install @octokit/core@5.1.0
 
     - name: Send reminders
       uses: actions/github-script@v7


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
**GitHub Issue:** #640 
Fixes : #640 

**Summary**:
-After trying to run using CommonJS, I encountered the same error that our workflow throws. However, after switching to ESM, it is working fine.
```
Earlier :
 const octokit = require('@octokit/core').Octokit;
          const mygithub = new octokit({
Latest : 
import { Octokit } from "@octokit/core";
          const mygithub = new Octokit({
```
- We need to run our workflow manually to check whether it is working fine or not.

**Do you think resolving this issue might require an [Architectural Decision Record (ADR)](https://github.com/json-schema-org/community/blob/main/CONTRIBUTING.md#key-architectural-decisions)? (significant or noteworthy)**
<!-- If the issue has the `adr-required`, this PR must include an ADR. -->
<!-- If you do not want to include an ADR, or are not sure how to make one, make sure you allow edits to this PR by maintainers. -->

Yes/No
[JUSTIFICATION]