### PR TITLE
Bug_report and workflow_suggestion templates added

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,20 +1,19 @@
-name: 🐛 Bug Report
-about: Create a report to help us improve our workflows
+name: "🐛 Bug Report"
+about: "Create a report to help us improve our workflows"
 title: "🐛 Bug: "
 labels: ["🐛 Bug", "Status: Triage"]
----
 
 body:
 - type: textarea
   attributes:
-    label: Describe the bug
-    description:  A clear and concise description of what the bug is
+    label: "Describe the bug"
+    description: "A clear and concise description of what the bug is"
   validations:
     required: true
 - type: textarea
   attributes:
-    label: Steps To Reproduce
-    description: Steps to reproduce the behavior
+    label: "Steps To Reproduce"
+    description: "Steps to reproduce the behavior"
     placeholder: |
       1. Go to'...'
       2. Click on'...'
@@ -24,13 +23,13 @@ body:
     required: true
 - type: textarea
   attributes:
-    label: Expected Behavior
-    description: A clear and concise description of what you expected to happen
+    label: "Expected Behavior"
+    description: "A clear and concise description of what you expected to happen"
   validations:
     required: true
 - type: textarea
   attributes:
-    label: Screenshots
+    label: "Screenshots"
     description: |
       If applicable, add screenshots to help explain your problem
 
@@ -39,7 +38,7 @@ body:
     required: false    
 - type: textarea
   attributes:
-    label: Device Information [optional]
+    label: "Device Information [optional]"
     description: |
       examples:
         - **OS**: Ubuntu 20.04
@@ -54,7 +53,7 @@ body:
     required: false
 - type: dropdown
   attributes:
-    label: Are you working on this issue?
+    label: "Are you working on this issue?"
     options:
       - 'Yes'
       - 'No'

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: "🐛 Bug Report"
-description: "Create a report to help us improve our workflows"
+description: "Create a report to help us improve our community workflows"
 title: "🐛 Bug: "
 labels: ["🐛 Bug", "Status: Triage"]
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,62 @@
+name: 🐛 Bug Report
+about: Create a report to help us improve our workflows
+title: "🐛 Bug: "
+labels: ["🐛 Bug", "Status: Triage"]
+---
+
+body:
+- type: textarea
+  attributes:
+    label: Describe the bug
+    description:  A clear and concise description of what the bug is
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Steps To Reproduce
+    description: Steps to reproduce the behavior
+    placeholder: |
+      1. Go to'...'
+      2. Click on'...'
+      3. Scroll down to'...'
+      4. See error
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Expected Behavior
+    description: A clear and concise description of what you expected to happen
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Screenshots
+    description: |
+      If applicable, add screenshots to help explain your problem
+
+      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in
+  validations:
+    required: false    
+- type: textarea
+  attributes:
+    label: Device Information [optional]
+    description: |
+      examples:
+        - **OS**: Ubuntu 20.04
+        - **Browser**: chrome
+        - **version**: 22
+    value: |
+        - OS:
+        - Browser:
+        - version:
+    render: markdown
+  validations:
+    required: false
+- type: dropdown
+  attributes:
+    label: Are you working on this issue?
+    options:
+      - 'Yes'
+      - 'No'
+  validations:
+    required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: "🐛 Bug Report"
-about: "Create a report to help us improve our workflows"
+description: "Create a report to help us improve our workflows"
 title: "🐛 Bug: "
 labels: ["🐛 Bug", "Status: Triage"]
 

--- a/.github/ISSUE_TEMPLATE/workflow_suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/workflow_suggestion.yml
@@ -1,7 +1,7 @@
-name: "💡 Workflow Suggestion"
+name: "💡 Community Workflow Suggestion"
 description: "Suggest a new community workflow"
-title: "💡 Workflow Suggestion: "
-labels: ["💡 Workflow Suggestion", "Status: Review"]
+title: "💡 Community Workflow proposal: "
+labels: ["✨ Enhancement", "Status: Triage"]
 
 body:
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/workflow_suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/workflow_suggestion.yml
@@ -1,0 +1,40 @@
+name: "💡 Workflow Suggestion"
+description: "Suggest a new community workflow"
+title: "💡 Workflow Suggestion: "
+labels: ["💡 Workflow Suggestion", "Status: Review"]
+
+body:
+- type: textarea
+  attributes:
+    label: "Description"
+    description: "A clear and concise description of the suggested workflow"
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: "Objective"
+    description: "What is the main goal or purpose of this workflow?"
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: "Steps"
+    description: "List the steps of the suggested workflow"
+    placeholder: |
+      1. Step 1
+      2. Step 2
+      3. Step 3
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: "Expected Outcome"
+    description: "A clear and concise description of what you expect to achieve with this workflow"
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: "Additional Context [optional]"
+    description: "Add any other context or information about the suggested workflow here"
+  validations:
+    required: false


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
**GitHub Issue:** #656 

**Summary**:
I have added two new issue templates 1. bug_report 2. new workflow_suggestion
Now, when users go to create a new issue, they'll have the option to choose either the "Bug Report" template or the "Workflow Suggestion" template, making it easier for them to provide the necessary information.

**Do you think resolving this issue might require an [Architectural Decision Record (ADR)](https://github.com/json-schema-org/community/blob/main/CONTRIBUTING.md#key-architectural-decisions)? (significant or noteworthy)**
No