### PR TITLE
Github action to remind the Office Hours session in Slack

### DIFF
--- a/.github/workflows/slack-ocwm-reminder.yml
+++ b/.github/workflows/slack-ocwm-reminder.yml
@@ -1,0 +1,78 @@
+name: Send reminders to join the OCWM
+
+on:
+  schedule:
+    - cron: '0 15 1-7 * 5' #Runs at 15:00, between day 1 and 7 of the month on Friday 
+    - cron: '0 15 1-7 * 2' #Runs at 15:00, between day 1 and 7 of the month on Tuesday
+
+jobs:
+  ocwm-reminders:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+    - name: Set up Node 20
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Install dependencies
+      run: npm install @octokit/core@5.1.0
+
+    - name: Send reminders
+      uses: actions/github-script@v7
+      env:
+        MY_TOKEN: ${{ secrets.AUTH_TOKEN }}
+        OWNER: ${{ vars.ORGANISATION }}
+        REPO: 'community'
+        OCWM_LABEL: ${{ vars.OCWM_LABEL }}
+        SLACK_WEBHOOK: ${{ vars.SLACK_WEBHOOK_REMINDER }}
+      with:
+        script: |
+        
+          const octokit = require('@octokit/core').Octokit;
+          const mygithub = new octokit({
+            request: { fetch: fetch,},
+            auth: process.env.MY_TOKEN
+          });
+
+          let targetLabel = encodeURIComponent(process.env.OCWM_LABEL);
+
+          const { data: workMeetings } = await mygithub.request(`GET /repos/${process.env.OWNER}/${process.env.REPO}/issues?labels=${targetLabel}&per_page=1`, {
+          })
+
+          const issueNumber = workMeetings[0].number
+          const newTitle = workMeetings[0].title;
+          const issueDate = newTitle.replace(/Open Community Working Meeting /g, "");
+          
+          //Date of the next meeting
+          const nextMeetingDate = new Date();
+          nextMeetingDate.setDate(nextMeetingDate.getDate() + (2 + 7 - nextMeetingDate.getDay()) % 7);
+          
+          const formattedDate = nextMeetingDate.toISOString().split('T')[0];
+          
+          const reminderText = (new Date().getDay() === 2) ? "today" : formattedDate;
+          
+          // Checking if the reminder should be sent
+          const today = new Date();
+          const firstTuesday = new Date(today.getFullYear(), today.getMonth(), 1);
+          firstTuesday.setDate(firstTuesday.getDate() + (2 + 7 - firstTuesday.getDay()) % 7);
+          const firstFriday = new Date(today.getFullYear(), today.getMonth(), 1);
+          firstFriday.setDate(firstFriday.getDate() + (5 + 7 - firstFriday.getDay()) % 7);
+          
+          if ((today.getDay() === 2 && today.getDate() === firstTuesday.getDate()) || (today.getDay() === 5 && today.getDate() === firstFriday.getDate() && firstFriday < firstTuesday)) {
+            // Notify Slack
+            const SLACK_WEBHOOK_URL = process.env.SLACK_WEBHOOK;
+            const SLACK_MESSAGE = `{
+              "issue": "https://github.com/${process.env.OWNER}/${process.env.REPO}/issues/${issueNumber}",
+              "date": "${reminderText}"
+            }`;
+
+            await fetch(SLACK_WEBHOOK_URL, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              body: SLACK_MESSAGE,
+            });
+          }


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
**GitHub Issue:** #663 

**Summary**:
This pull request adds a new GitHub Action that sends reminders to join the Office Hours session on the Friday before the session and on the same day of the session.
The GitHub Action is scheduled to run at 15:00 every Friday and at 9:00 every Tuesday. It uses the @octokit/core package to fetch the latest issue with the OCWM_LABEL label from the repository. It then sends a message to the Slack channel with the issue link and date.

**Do you think resolving this issue might require an [Architectural Decision Record (ADR)](https://github.com/json-schema-org/community/blob/main/CONTRIBUTING.md#key-architectural-decisions)? (significant or noteworthy)**
<!-- If the issue has the `adr-required`, this PR must include an ADR. -->
<!-- If you do not want to include an ADR, or are not sure how to make one, make sure you allow edits to this PR by maintainers. -->
No