### PR TITLE
Update gsoc-2024.md to strikethrough unaccepted projects

### DIFF
--- a/programs/mentoring/gsoc/gsoc-2024.md
+++ b/programs/mentoring/gsoc/gsoc-2024.md
@@ -23,8 +23,6 @@ JSON Schema will be applying to 2024's Google Summer of Code Program as a mentor
 
 ## [Project Ideas](https://github.com/json-schema-org/community/issues?q=is%3Aopen+label%3Agsoc+sort%3Acreated-desc)
 Here is the list of our 2024 project ideas:
-- ~~[#609](https://github.com/json-schema-org/community/issues/609): **New Bowtie Test Case Widgets**~~
-- ~~[#606](https://github.com/json-schema-org/community/issues/606): **jsonschema.lean -- an implementation of JSON Schema in Lean**~~
 - [#607](https://github.com/json-schema-org/community/issues/607): **`bowtie-trend`: Long-Term Reporting With Bowtie**
 - [#605](https://github.com/json-schema-org/community/issues/605): **`bowtie-perf`: a Performance Tester for JSON Schema implementations**
 - [#603](https://github.com/json-schema-org/community/issues/603): **Setting up the CI/CD Pipeline for the JSON Schema website**
@@ -33,6 +31,8 @@ Here is the list of our 2024 project ideas:
 - [#599](https://github.com/json-schema-org/community/issues/599): **Define upgrade/downgrade language agnostic declarative transformation rules for all JSON Schema dialects**
 - [#614](https://github.com/json-schema-org/community/issues/614): **Source Generation Analyzer Powered by Corvus.JsonSchema (.Net)**
 - [#645](https://github.com/json-schema-org/community/issues/645): **A tour of JSON Schema**
+- ~~[#609](https://github.com/json-schema-org/community/issues/609): **New Bowtie Test Case Widgets**~~
+- ~~[#606](https://github.com/json-schema-org/community/issues/606): **jsonschema.lean -- an implementation of JSON Schema in Lean**~~
 
 ## Why choosing a JSON Schema project?
 

--- a/programs/mentoring/gsoc/gsoc-2024.md
+++ b/programs/mentoring/gsoc/gsoc-2024.md
@@ -23,9 +23,9 @@ JSON Schema will be applying to 2024's Google Summer of Code Program as a mentor
 
 ## [Project Ideas](https://github.com/json-schema-org/community/issues?q=is%3Aopen+label%3Agsoc+sort%3Acreated-desc)
 Here is the list of our 2024 project ideas:
-- [#609](https://github.com/json-schema-org/community/issues/609): **New Bowtie Test Case Widgets**
+- ~~[#609](https://github.com/json-schema-org/community/issues/609): **New Bowtie Test Case Widgets**~~
+- ~~[#606](https://github.com/json-schema-org/community/issues/606): **jsonschema.lean -- an implementation of JSON Schema in Lean**~~
 - [#607](https://github.com/json-schema-org/community/issues/607): **`bowtie-trend`: Long-Term Reporting With Bowtie**
-- [#606](https://github.com/json-schema-org/community/issues/606): **jsonschema.lean -- an implementation of JSON Schema in Lean**
 - [#605](https://github.com/json-schema-org/community/issues/605): **`bowtie-perf`: a Performance Tester for JSON Schema implementations**
 - [#603](https://github.com/json-schema-org/community/issues/603): **Setting up the CI/CD Pipeline for the JSON Schema website**
 - [#602](https://github.com/json-schema-org/community/issues/602): **Build a new version of the JSON Schema tooling page**


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
**GitHub Issue:** # / NA

**Summary**: Update gsoc-2024.md to strikethrough unaccepted projects

**Do you think resolving this issue might require an [Architectural Decision Record (ADR)](https://github.com/json-schema-org/community/blob/main/CONTRIBUTING.md#key-architectural-decisions)? (significant or noteworthy)**
<!-- If the issue has the `adr-required`, this PR must include an ADR. -->
<!-- If you do not want to include an ADR, or are not sure how to make one, make sure you allow edits to this PR by maintainers. -->

No