### PR TITLE
Manage adopters directly from the Landscape.

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,28 +1,28 @@
 # Adopters
 
-**📢 If you're using JSON Schema in your organization, please add your company name to this list.**
+🚨 **Update - June 2024** 🚨
+---
+We are so excited to share that we launched the [JSON Schema Landscape](https://landscape.json-schema.org/) as the visual representation of the JSON Schema Ecosystem. With this new and exciting initiative we have a duplicity between this Adopters list and [the Adopters group in Landscape](https://landscape.json-schema.org/?group=adopters), therefore we have decided to manage the adopters list directly in the landscape (See the landscape guide [here](https://landscape.json-schema.org/guide#introduction--adopters)).
+
+**📢 If you're using JSON Schema in your organization, please add your company to the adopters list.**
 
 **🙏 It really helps the project to gain momentum and credibility. It's a small contribution back to the project with a big impact.**
 
-## Why add your company name?
+## Why add your company?
 
 - Demonstrates the real-world usage of JSON Schema.
 - Provides visibility to organizations that have successfully adopted JSON Schema.
 - Encourages other organizations to adopt JSON Schema.
 - Builds trust in the JSON Schema ecosystem.
 
-This document also lists the organizations that use JSON Schema based on public information available in blog posts, events, and videos. If any organization would like to be added or get removed please make a Pull Request.
+If any organization would like to be added or get removed please make a Pull Request.
 
 ## How to add your company
 
-You can add your Company by using the [Adopter form](https://forms.gle/vyFskw1RshJ55LY46) or by editing this file after following the [CONTRIBUTING.md](./CONTRIBUTING.md).
-
-Guidelines:
-- Please don't include your organization's logo or other trademarked material
-- Add a reference (link to a public blog post, video, slides, etc) mentioning that JSON Schema is used
-- Please include a contact link for maintainers
+You can add your Company by using the [Adopter form](https://forms.gle/vyFskw1RshJ55LY46) or by submitting a PR editting the [landscape.yml](https://github.com/json-schema-org/landscape/blob/main/landscape.yml) file in the [landscape repository](https://github.com/json-schema-org/landscape/).
 
 Looking for extra credit? We also do [case studies](https://github.com/orgs/json-schema-org/projects/8/views/2) and accept sponsorship via [Open Collective](https://opencollective.com/json-schema).
+
 <details>
 <summary>Find out more about case studies</summary>
 If your company would like to share more about what you're doing in public, there's a good chance we'd love to collaborate on a case study.
@@ -31,88 +31,9 @@ Please reach out to us via [our Slack](https://json-schema.org/slack) or creatin
 
 From exerience, these case studies can take some time to develop, write, get approved, and published. It's best if you can find out for sure if you can publish a case study with us as early as possible. If you're at a big organization, you'll likely have to get approval from people who have no idea what you're talking about. Here's some context you can share with them.
 
-JSON Schema is an [OpenJS Foundation](https://openjsf.org/about) Project, under [The Linux Foundation](https://www.linuxfoundation.org/). Both the OpenJS Foundation and The Linux Foundation are registered non-profit organizations (501(c)(6)).
-
 By supporting JSON Schema with a case study, you are documenting its success and your smarts in picking it as a solution. JSON Schema case studies help justify the ongoing financial support required to mature, develop, and support the JSON Schema ecosystem. Case studies also demonstrate the strength of the JSON Schema ecosystem in production today. The next case study could be you.
 </details>
 
-(ordered alphabetically)
+### The JSON Schema Adopters list
 
-| Organization | Contact | Description of Use / Reference |
-| --- | --- | --- |
-| [Authsignal](https://www.authsignal.com/) | Infer typescript types for HTTP request/response models (using the json-schema-to-ts library). |
-| [Automatic Data Processing (ADP)](https://www.adp.com/) | [Jeremy Fiel](mailto:jeremy.fiel@adp.com?subject=I%20love%20JSON%20Schema%20too!) | [ADP Developer Resources](https://developers.adp.com/welcome) |
-| [Cookpad](https://cookpad.com/) | [Kenshi Shiode](https://www.linkedin.com/in/kenshi-shiode-b65922212/) | [Cookpad JSON Schema case study](https://json-schema.org/blog/posts/cookpad-case-study-en) |
-| [Cyclops](https://cyclops-ui.com/) | [Petar Cvitanović](https://www.linkedin.com/in/petar-cvit/) | [Cyclops is a powerful user interface for managing and interacting with Kubernetes clusters](https://cyclops-ui.com/blog/2023/11/13/JSON-schemas) |
-| [Dashjoin](https://dashjoin.com/) | [Andreas Eberhart](https://www.linkedin.com/in/andreas-eberhart-94264a44/) | [Dashjoin Is an Open Source & Cloud Native Low Code Development and Integration Platform That Helps Teams Deliver AI Empowered Applications Faster. The platform leverages popular JSON standards like JSON Schema and JSONata and for all aspects of the system. Specifically, Dashjoin Platform allows connecting to multiple databases (relational, graph and document) and all database structures are scanned and represented using JSON Schema.](https://dashjoin.github.io/platform/latest/) |
-| [F5](https://www.f5.com/) | [Kin Lane](https://www.linkedin.com/in/kinlane/) | [F5 - JSON Schema in production episode](https://youtu.be/pibZF049zqE) |
-| [GitHub](https://github.com/) | [Rachael Sewell](https://www.linkedin.com/in/rachaelsewell/)<br/>[Robert Sese](https://www.linkedin.com/in/rsese/) | [Github JSON Schema case study](https://json-schema.org/blog/posts/github-case-study) |
-| [Tyler Technology](https://www.tylertech.com/) | [Andres Moreno](https://www.linkedin.com/in/andmoredev/) | [Tyler Technology JSON Schema case study](https://json-schema.org/blog/posts/tyler-technologies-case-study) |
-| [HAPI Specification](https://hapi-server.org/) | [Jeremy Faden](https://cottagesystems.com/) | [Server responses can be verified against a schema, accelerating development of correct servers](https://github.com/hapi-server/data-specification-schema) |
-| [Helm](https://helm.sh/) | [The Helm Community](https://github.com/helm/community) | [Helm uses JSON Schema to validate their values files.](https://helm.sh/docs/topics/charts/#schema-files)|
-| [Invopop](https://www.invopop.com/) | [Sam Lown](https://www.linkedin.com/in/samlown/) | [Invopop helps global companies comply with local tax reporting requirements. Invopop uses JSON Schema at the core of their GOBL SDK to build, share, and convert invoices globally](https://docs.gobl.org/introduction) |
-| [kickstartDS](https://www.kickstartDS.com/) | [Jonas Ulrich](https://www.linkedin.com/in/jonas-ulrich-b0a7b0222/) | [kickstartDS uses JSON Schema to document component APIs in Design Systems. Those get rewritten to headless CMS-specific configuration files through converters](https://dev.to/kickstartds/unlocking-the-frontend-a-call-for-standardizing-component-apis-pt2-e77) |
-| [KrakenD](https://www.krakend.io/) | [Albert Lombarte](https://www.linkedin.com/in/alombarte/) | [KrakenD is a high-performance API Gateway offering JSON Schema validation in requests, responses, config validation, and documentation](https://www.krakend.io/blog/json-schema-use-case/) |
-| [Manfred](https://www.getmanfred.com/) | [David Bonilla](https://www.linkedin.com/in/dbonillaf/) | [The MAC is a standard open source format created by Manfred to define and share CVs](https://github.com/getmanfred/mac) |
-| [Microsoft](https://www.microsoft.com/) | [Mads Kristensen](https://www.linkedin.com/in/madskvistkristensen/) | [Microsoft - JSON Schema in production episode](https://youtu.be/-yYTxLZZk58) |
-| [OpenMetadata](https://open-metadata.org/) | [Suresh Srinivas](https://www.linkedin.com/in/sureshsri/) | [OpenMetadata - JSON Schema in production episode](https://youtu.be/ZrVTZwmTR3k) |
-| [Postman](https://www.postman.com/) | [Juan Cruz Viotti](https://www.linkedin.com/in/jviotti/) | [Postman JSON Schema case study](https://json-schema.org/blog/posts/postman-case-study) |
-| [Remote](https://remote.com/) | [Sandrina Pereira](https://www.linkedin.com/in/sandrina-p/) | [Remote JSON Schema case study](https://json-schema.org/blog/posts/remote-case-study) |
-| [Stedi](https://www.stedi.com/) | [Brian Quinn](https://www.linkedin.com/in/bdquinn/) | [Stedi Guides – powered by JSON Schema](https://www.stedi.com/docs/edi-platform/operate/transform-json/guide-json#find-a-guides-json-schema) |
-| [W3C Web of Things](https://www.w3.org/WoT/) | [Ege Korkan](https://www.linkedin.com/in/ege-korkan/) | [W3C Web of Things JSON Schema case study](https://json-schema.org/blog/posts/w3c-wot-case-study) |
-| [Waylit](https://www.waylit.com/) | [Satya Mishra](https://www.linkedin.com/in/satyamishra/) | [WayLit helps customers and their employees by making immigration a bit easier. Waylit uses JSON Schema to generate nice-looking adaptive forms and validate all the collected data](https://www.waylit.com/post/more-than-1000-form-fields-and-growing-how-waylit-uses-json-schema) |
-| [Wundergraph](https://wundergraph.com/) | [Jens Neuse](https://www.linkedin.com/in/jens-neuse-706673195/) | [Wundergraph - JSON Schema in production episode](https://youtu.be/_TCU6da0GA8) |
-| [Zapier](https://zapier.com/) | [David Brownman](https://www.linkedin.com/in/xavdid/) | [Zapier - JSON Schema in production episode](https://youtu.be/yDL98sd4KVE) |
-| Zones | [Chuck Reeves](https://www.linkedin.com/in/charles-reeves-156953284/) | [Zones - JSON Schema in production episode](https://youtu.be/fkziMQD7pqQ) |
-
-The previouse list contains the organizations that have opted to join the adopters of JSON Schema, although there are many others that also use it. Below, you will find a list of organizations known to utilize JSON Schema. Feel free to edit this list by adding any organization that has publicly disclosed its use of JSON Schema.
-
-(ordered alphabetically)
-
-- [Adobe Experience Manager](https://experienceleague.adobe.com/docs/experience-manager-65/forms/adaptive-forms-advanced-authoring/adaptive-form-json-schema-form-model.html?lang=en?utm_source=awesome-jsonschema) - The Adobe Experience Manager content management solution for building websites, mobile apps and forms supports creating adaptative forms using JSON Schema.
-- [Amazon EventBridge Schema Registry](https://aws.amazon.com/about-aws/whats-new/2020/09/amazon-eventbridge-schema-registry-announces-support-for-json-schema/?utm_source=awesome-jsonschema) - Amazon EventBridge Schema Registry has support for JSON Schema, allowing customers to validate, annotate, and manipulate JSON documents conforming to JSON Schema Draft 4 specification.
-- [Apiary](https://help.apiary.io/api_101/json-schema/?utm_source=awesome-jsonschema) - Apiary&#x27;s interactive documentation is able to render JSON Schema documents associated with payloads.
-- [Assertible](https://assertible.com/json-schema-validation?utm_source=awesome-jsonschema) - Assertible provides a free-to-use API to validate a JSON document against a JSON Schema and a service to test and monitor web services using JSON Schema.
-- [Axway API Gateway](https://docs.axway.com/bundle/APIGateway_762_PolicyDevFilterReference_allOS_en_HTML5/page/Content/PolicyDevTopics/content_schema_json.htm?utm_source=awesome-jsonschema) - The API Gateway can check that JavaScript Object Notation (JSON) messages conform to the format expected by a web service by validating requests against a specified JSON schema.
-- [Cloudflare](https://blog.cloudflare.com/cloudflares-json-powered-documentation-generator/?utm_source=awesome-jsonschema) - The Cloudflare makes use of JSON Schema and Hyper Schema to keep track of their API endpoints.
-- [Cloudflare Terraform](https://www.infoq.com/news/2021/04/cloudflare-terraform/?utm_source=awesome-jsonschema) - The Cloudflare Terraform provider comes with a tool to generate Terraform configuration from existing Cloudflare resources that uses JSON Schema to map data between both technologies.
-- [Confluent Schema Registry](https://docs.confluent.io/platform/current/schema-registry/serdes-develop/serdes-json.html?utm_source=awesome-jsonschema) - JSON Schema can be configured with the Apache Kafka Java client and console tools to fail if the payload is not valid for the given schema.
-- [Contentstack](https://www.contentstack.com/docs/developers/create-content-types/json-schema-for-creating-a-content-type/?utm_source=awesome-jsonschema) - The Contentstack CMS platform supports creating content types using JSON Schema.
-- [Decisions](https://documentation.decisions.com/docs/create-types-json-schema?utm_source=awesome-jsonschema) - The Decisions rules-driven business process automation platform support using JSON Schema to generate JSON deserializers.
-- [DocSpring](https://docspring.com/docs/api/get_template_schema.html?utm_source=awesome-jsonschema) - The DocSpring service to automatically fill out PDF forms supports generating JSON Schema definitions for user-created templates.
-- [Drupal Patternkit](https://www.drupal.org/project/patternkit?utm_source=awesome-jsonschema) - The Drupal Patternkit module uses JSON Schema to define pattern templates.
-- [Form.io](https://www.form.io/article/angular-json-schema-form-builder?utm_source=awesome-jsonschema) - The Form.io online web form generator supports generating Angular.js forms using JSON Schema.
-- [Genomic Data Commons](https://gdc.cancer.gov/developers/gdc-data-model?utm_source=awesome-jsonschema) - The Genomic Data Commons data model is defined using JSON Schema.
-- [Hackolade](https://hackolade.com/help/JSONSchema.html?utm_source=awesome-jsonschema) - The Hackolade data modelling service supports defining entities using JSON Schema.
-- [Heroku](https://blog.heroku.com/json_schema_for_heroku_platform_api?utm_source=awesome-jsonschema) - Heroku makes use of JSON Schema to publish machine-readable schema definitions for their public APIs.
-- [Human Cell Atlas](https://data.humancellatlas.org/metadata/structure?utm_source=awesome-jsonschema) - The open data generated by the Human Cell Atlas describes metadata structure using JSON Schema.
-- [IBM App Connect](https://www.ibm.com/docs/en/app-connect/11.0.0?topic=schema-json-requirements-message-maps?utm_source=awesome-jsonschema) - The Graphical Data Mapping editor can be used to create and transform JSON messages with the data model defined from a JSON schema.
-- [Informatica](https://docs.informatica.com/data-integration/b2b-data-transformation/10-2-2/user-guide/wizard-input-and-output-formats/json/sample-json-schema.html?utm_source=awesome-jsonschema) - The Informatica data management platform supports creating auto-generated data processor transformations using JSON Schema.
-- [JSON BinPack](https://www.jsonbinpack.org?utm_source=awesome-jsonschema) - JSON BinPack uses JSON Schema to perform space-efficient JSON binary serialization.
-- [JSON:API](https://github.com/json-api/json-api/blob/a0296352b6eb57a4ea3eb08a1332e311f78adafa/schema?utm_source=awesome-jsonschema) - The JSON:API 1.0 and later specifications for building APIs in JSON use JSON Schema to define JSON:API responses.
-- [JamF](https://docs.jamf.com/technical-papers/jamf-pro/json-schema/10.26.0/Understanding_the_Structure_of_a_JSON_Schema_Manifest.html?utm_source=awesome-jsonschema) - The JamF Apple enterprise management service supports creating app manifests using JSON Schema.
-- [JetBrains](https://www.jetbrains.com/help/objc/json.html?utm_source=awesome-jsonschema) - The suite of JetBrains programming editors supports JSON code-completion based on JSON Schema.
-- [Lightblue.io](https://docs.lightblue.io/standards/json_schema.html?utm_source=awesome-jsonschema) - The Lightblue document based data access layer framework uses JSON Schema to define certain file resources in the project.
-- [Linux](https://www.kernel.org/doc/html/latest/devicetree/bindings/writing-schema.html?utm_source=awesome-jsonschema) - The Linux kernel uses JSON Schema to define Devicetree bindings.
-- [MongoDB](https://docs.mongodb.com/manual/reference/operator/query/jsonSchema/?utm_source=awesome-jsonschema) - MongoDB 3.6 and later support JSON Schema for querying data and defining collection constraints.
-- [Mozilla Data Pipeline](https://docs.telemetry.mozilla.org/concepts/pipeline/schemas.html?utm_source=awesome-jsonschema) - Mozilla Data Pipeline uses JSON Schema to define telemetry data ingested from Mozilla products and logs from various services.
-- [MuleSoft](https://docs.mulesoft.com/json-module/2.1/json-schema-validation?utm_source=awesome-jsonschema) - The MuleSoft integration framework supports validating a JSON document against a JSON Schema.
-- [MySQL](https://dev.mysql.com/doc/refman/8.0/en/json-validation-functions.html?utm_source=awesome-jsonschema) - MySQL 8.0.17 and later support table constraints to validate a JSON document against a JSON Schema.
-- [Nakadi](https://nakadi.io?utm_source=awesome-jsonschema) - The Nakadi open-source distributed event bus supports defining event types with JSON Schema.
-- [National Cancer Institute](https://github.com/NCI-GDC/gdcdictionary/tree/develop/gdcdictionary/schemas?utm_source=awesome-jsonschema) - The National Cancer Institute uses JSON Schema to model entities for their Genomic Data Commons collection.
-- [NinJS](https://www.iptc.org/std/ninjs/userguide/?utm_source=awesome-jsonschema) - NinJS standardises the representation of news content in JSON and maintains a JSON Schema document to help validate NinJS implementations.
-- [Open Policy Agent (OPA)](https://blog.openpolicyagent.org/enhanced-type-checking-for-opa-with-json-schema-annotations-826acb0f575?utm_source=awesome-jsonschema) - The OPA policy-based control platform 0.27.0 and newer support statically type-checking Rego policy code using JSON Schema.
-- [Ory Kratos](https://www.ory.sh/kratos/docs/reference/json-schema-json-paths/?utm_source=awesome-jsonschema) - The Ory Kratos identity &amp; user management product relies on JSON Schema from configuration validation, documentation generation for defining identity schemas.
-- [RDA DMP Common Standard for machine-actionable Data Management Plans](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard?utm_source=awesome-jsonschema) - The RDA DMP Common Standards Working Group maintains JSON Schemas to validate maDMP JSON documents.
-- [RESTHeart](https://restheart.org/docs/json-schema-validation/?utm_source=awesome-jsonschema) - RESTHeart supports MongoDB schema validation to enforce a format to documents: rules-based validation from MongoDB 3.2 and Json Schema validation from MongoDB 3.6.
-- [Retool](https://docs.retool.com/docs/working-with-json-schema-form?utm_source=awesome-jsonschema) - The Retool no-code platform supports generating web forms using JSON Schema.
-- [Serverless](https://www.serverless.com/framework/docs/configuration-validation/?utm_source=awesome-jsonschema) - The Serverless framework validates service configuration files using JSON Schema.
-- [Smart Data Models](https://github.com/smart-data-models?utm_source=awesome-jsonschema) - The Smart Data Models GitHub organization makes use of JSON Schema to describe harmonized Data Models for different Smart Domains.
-- [Snowplow](https://docs.snowplowanalytics.com/docs/understanding-tracking-design/understanding-schemas-and-validation/?utm_source=awesome-jsonschema) - The Snowplow analytics platform support using JSON Schema to define the structure of the data to collect.
-- [SpreadJS](https://www.grapecity.com/spreadjs/docs/v13/online/jsonschema.html?utm_source=awesome-jsonschema) - The SpreadJS JavaScript spreadsheet library uses JSON Schema to describe the SpreadJS JSON data format.
-- [TILT (machine-readable privacy policies)](https://github.com/Transparency-Information-Language/schema?utm_source=awesome-jsonschema) - TILT is a transparency information language and toolkit powered by JSON Schema explicitly designed to represent and process transparency information in line with the requirements of the EU General Data Protection Regulation and allowing for a more automated and adaptive use of such information than established, legalese data protection policies do.
-- [U.S. Department of Commerce](https://github.com/usnistgov/OSCAL/tree/main/json?utm_source=awesome-jsonschema) - The National Institute of Standards and Technology uses JSON Schema Draft 7 to model Open Security Controls Assessment Language (OSCAL) JSON documents.
-- [Walmart eCommerce](https://developer.walmart.com/documentation/item-object-v4-0/?utm_source=awesome-jsonschema) - Walmart publishes JSON Schema documents for certain resources that developers can make use of when integratting with the Walmart eCommerce platform.
-- [Wordpress](https://make.wordpress.org/themes/2021/11/30/theme-json-schema/?utm_source=awesome-jsonschema) - Wordpress maintains official JSON Schema documents to help with building block based themes.
-- [Zuplo](https://zuplo.com/json-schema/lp-a?utm_source=awesome-jsonschema) - The Zuplo API gateway provides JSON Schema validation and supports generating API documentation out of OpenAPI specifications.
-- [nf-core](https://nf-co.re/tools/#pipeline-schema?utm_source=awesome-jsonschema) - The nf-core Nextflow analysis pipelines collection uses JSON Schema to define the parameters used by Nextflow workflows.
+Please visit the JSON Schema Landscape to see the full list: https://landscape.json-schema.org/

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -19,7 +19,7 @@ If any organization would like to be added or get removed please make a Pull Req
 
 ## How to add your company
 
-You can add your Company by using the [Adopter form](https://forms.gle/vyFskw1RshJ55LY46) or by submitting a PR editting the [landscape.yml](https://github.com/json-schema-org/landscape/blob/main/landscape.yml) file in the [landscape repository](https://github.com/json-schema-org/landscape/).
+You can add your Company by using the [Adopter form](https://forms.gle/vyFskw1RshJ55LY46) or by submitting a PR editting the [landscape.yml](https://github.com/json-schema-org/landscape/blob/main/landscape.yml) file in the [landscape repository](https://github.com/json-schema-org/landscape/). For more information please check the [contributing guidelines](https://github.com/json-schema-org/landscape/blob/main/CONTRIBUTING.md#adding-a-new-organization-) of the Landscape project.
 
 Looking for extra credit? We also do [case studies](https://github.com/orgs/json-schema-org/projects/8/views/2) and accept sponsorship via [Open Collective](https://opencollective.com/json-schema).
 

--- a/programs/adopters/templates/socialmedia-promotion.md
+++ b/programs/adopters/templates/socialmedia-promotion.md
@@ -1,31 +1,32 @@
 ### Twitter Template
 
-📣 🎉 We are pleased to welcome ____ to the official list of JSON Schema adopters!
+📣 We are pleased to welcome _______ to the JSON Schema adopters list!
 
-_______ is a 
+XXXXXXX is a _______
 
-More about JSON Schema Adopters list ➡️ https://github.com/json-schema-org/community/blob/main/ADOPTERS.md
+https://
 
-🧐🧵
-
-Know more about _______ use case :
+Visit our landscape and discover more orgnizations using JSON Schema : https://landscape.json-schema.org
 
 ### Linkedin Template
 
-📣 🎉 We are pleased to welcome ______ to the official list of JSON Schema adopters!
+📣 🎉 We are pleased to welcome _______ to the official list of JSON Schema adopters!
 
-________ is a 
+_______ is a ....
 
-Know more about ______ use case 💡 
+More about _______ 👉 https://
 
-More about JSON Schema Adopters list ➡️ https://github.com/json-schema-org/community/blob/main/ADOPTERS.md
+Check out the JSON Schema Landscape to explore the leading orgnizations using JSON Schema: https://landscape.json-schema.org/
+
+#ecosystem #jsonschema #adopters #production
+
 
 ### Slack
 
-:mega: :tada: We are pleased to welcome ______ to the official list of :star: JSON Schema adopters :star:!
+:mega: :tada: We are pleased to welcome _______ to the official list of JSON Schema adopters!
+
 ______ is a ....
 
-Know more about JSON Schema Adopters :arrow_right: https://github.com/json-schema-org/community/blob/main/ADOPTERS.md
-Know more about _____ use case :bulb: 
+Check out the JSON Schema Landscape to explore the leading orgnizations using JSON Schema: https://landscape.json-schema.org/
 
-Is your Organization using JSON Schema? Please join the [Adopters list](https://github.com/json-schema-org/community/blob/main/ADOPTERS.md) and help us to grow the JSON Schema Ecosystem by sharing your use case.
+Is your Organization using JSON Schema? Please join the Adopters group in the JSON Schema Landscape and help us to grow the JSON Schema Ecosystem by sharing your use case.


### PR DESCRIPTION
 - Related https://github.com/json-schema-org/landscape/pull/68

**Summary**:

This PR is intended to change the way in how we provision the Adopters file as we now have two similar features with the Landscape. Moving forward we'll manage all the adopters from the Landscape project.
