### PR TITLE
chore(github-actions) : Fixes notify-failed-actions workflow

### DIFF
--- a/.github/workflows/failed-actions-notify.yml
+++ b/.github/workflows/failed-actions-notify.yml
@@ -8,36 +8,30 @@ on:
     branches:
       - main
 
-jobs:
-  notify-slack:
-    runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
+permissions:
+  actions: read
 
-      - name: Send Slack notification
+jobs:
+  on-failure:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event.workflow_run.conclusion == 'failure' || 
+      github.event.workflow_run.conclusion == 'timed_out') &&
+      github.event.workflow_run.name != 'Slack Notifications for Failed GitHub Actions'
+    timeout-minutes: 10
+    steps:
+      - name: Send Slack Notification
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ github.event.workflow_run.conclusion }}
+          notification_title: " ${{github.event.workflow_run.name}} - ${{github.event.workflow_run.conclusion}} on ${{github.event.workflow_run.head_branch}} - <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}|View Failure>"
+          message_format: ":fire: *${{github.event.workflow_run.name}}* ${{github.event.workflow_run.conclusion}} in <${{github.server_url}}/${{github.repository}}/${{github.event.workflow_run.head_branch}}|${{github.repository}}>"
+          footer: "Linked Repo <${{github.server_url}}/${{github.repository}}|${{github.repository}}> | <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}|View Failure>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_REMINDER }}
+      
+      - name: Check Slack Notification Status
         if: failure()
         run: |
-          const fetch = require('node-fetch');
-
-          const SLACK_WEBHOOK_URL = process.env.SLACK_WEBHOOK_URL;
-          const context = JSON.parse(process.env.GITHUB_CONTEXT);
-
-          const slackMessage = {
-            channel: '#github',
-            issue: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-            status: context.jobStatus,
-            text: `GitHub Actions workflow failed: ${context.workflow}`
-          };
-
-          await fetch(SLACK_WEBHOOK_URL, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(slackMessage),
-          });
-        env:
-          SLACK_WEBHOOK_URL: ${{ vars.SLACK_WEBHOOK_FAIL_ACTIONS }}
-          GITHUB_CONTEXT: ${{ toJson(github) }}
+          echo "Failed to send Slack notification"
+          echo "Workflow Run ID: ${{ github.event.workflow_run.id }}"

--- a/.github/workflows/failed-actions-notify.yml
+++ b/.github/workflows/failed-actions-notify.yml
@@ -28,7 +28,7 @@ jobs:
           message_format: ":fire: *${{github.event.workflow_run.name}}* ${{github.event.workflow_run.conclusion}} in <${{github.server_url}}/${{github.repository}}/${{github.event.workflow_run.head_branch}}|${{github.repository}}>"
           footer: "Linked Repo <${{github.server_url}}/${{github.repository}}|${{github.repository}}> | <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}|View Failure>"
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_REMINDER }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_WORKFLOW_NOTIF }}
       
       - name: Check Slack Notification Status
         if: failure()


### PR DESCRIPTION
<!-- In order to keep off-topic discussion to a minimum, it helps if the "work to be done" is already agreed upon. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded and linked to in this PR. -->
Closes: #737 

**Summary**:
- When any workflow fails, this workflow will notify about the failed workflow on GitHub Actions.

**Notes**:
- There might be a need to change the Slack webhook URL because this workflow should notify only on the Slack GitHub channel.
- Also, this workflow is using `secrets` for the webhook URL, while other workflows need to be updated to use secrets instead of vars.

**Do you think resolving this issue might require an [Architectural Decision Record (ADR)](https://github.com/json-schema-org/community/blob/main/CONTRIBUTING.md#key-architectural-decisions)? (significant or noteworthy)**
<!-- If the issue has the `adr-required` label, this PR must include an ADR. -->
<!-- If you do not want to include an ADR, or are not sure how to make one, make sure you allow edits to this PR by maintainers. -->
No
[No justification required as the change does not appear to be architecturally significant.]