### PR TITLE
Update open_community_working_meeting.md to fix meeting link

### DIFF
--- a/.github/ISSUE_TEMPLATE/open_community_working_meeting.md
+++ b/.github/ISSUE_TEMPLATE/open_community_working_meeting.md
@@ -5,7 +5,7 @@ about: Regular Open Community Working Meetings Issue - This template is for thos
 
 # Open Community Working Meeting 2022-MM-DD - 14:00 PT
 
-Zoom Meeting link: https://postman.zoom.us/j/89562933116?pwd=OWlsQ0RrcDY4S1JQU2d2Q2M0aFFlZz09
+Google Meet joining info - Video call link: https://meet.google.com/rag-mhbi-cgt
 
 You can find these events scheduled on our **[JSON Schema Community Calendar](https://calendar.google.com/calendar/u/0/embed?src=info@json-schema.org)**.
 


### PR DESCRIPTION
Added a new meeting link using Google Meet.

**Summary**:

After losing access to Postman's Zoom account we need a new tool to manage the community meetings. I just added a Google Meet link while we close the TSC voting issue: https://github.com/json-schema-org/TSC/issues/10
