### PR TITLE
added startedOn and lastReviewedOn

### DIFF
--- a/programs/ambassadors/ambassadors-schema.json
+++ b/programs/ambassadors/ambassadors-schema.json
@@ -89,8 +89,44 @@
           },
           "required": ["type", "title", "date", "link"]
         }
+      },
+      "startedOn": {
+        "type": "object",
+        "description": "Date of start",
+        "properties": {
+          "year": {
+            "type": "integer",
+            "minimum": 1900,
+            "maximum": 2100,
+            "description": "Year of start"
+          },
+          "month": {
+            "type": "string",
+            "enum": ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
+            "description": "Month of start"
+          }
+        },
+        "required": ["year", "month"]
+      },
+      "lastReviewedOn": {
+        "type": "object",
+        "description": "Date of last reviewed",
+        "properties": {
+          "year": {
+            "type": "integer",
+            "minimum": 1900,
+            "maximum": 2100,
+            "description": "Year of last reviewed"
+          },
+          "month": {
+            "type": "string",
+            "enum": ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
+            "description": "Month of last reviewed"
+          }
+        },
+        "required": ["year", "month"]
       }
     },
-    "required": ["name", "img", "bio", "title", "github", "company", "country", "contributions"]
+    "required": ["name", "img", "bio", "title", "github", "company", "country", "contributions", "startedOn"]
   }
 }

--- a/programs/ambassadors/ambassadors.json
+++ b/programs/ambassadors/ambassadors.json
@@ -46,7 +46,11 @@
         },
         "link": "https://dashjoin.medium.com/json-schema-openapi-low-code-a-match-made-in-heaven-d29723e543ac"
       }
-    ]
+    ],
+    "startedOn": {
+        "year": 2024,
+        "month": "July"
+    }
   },      
   {
     "name": "David Biesack",
@@ -113,7 +117,11 @@
         },
         "link": "https://www.youtube.com/watch?v=6ukZEUBRpqo"
       }
-    ]
+    ],
+    "startedOn": {
+        "year": 2024,
+        "month": "July"
+    }
   },
   {
     "name": "Juan Cruz Viotti",
@@ -179,7 +187,11 @@
         },
         "link": "https://github.com/json-schema-org/community/issues/599"
       }
-    ]
+    ],
+    "startedOn": {
+        "year": 2024,
+        "month": "August"
+    }
   },
   {
     "name": "Esther Okafor",
@@ -228,7 +240,11 @@
         },
         "link": "https://www.canva.com/design/DAGJgnhNUYA/GLVTP-Yx7wcBVFjOhsN2uQ/edit?utm_content=DAGJgnhNUYA&utm_campaign=designshare&utm_medium=link2&utm_source=sharebutton"
       }
-    ]
+    ],
+    "startedOn": {
+        "year": 2024,
+        "month": "August"
+    }
   },
   {
     "name": "Ege Korkan",
@@ -296,7 +312,11 @@
         },
         "link": "https://github.com/eclipse-thingweb/playground/tree/master/packages/json-spell-checker"
       }
-    ]
+    ],
+    "startedOn": {
+        "year": 2024,
+        "month": "August"
+    }
   },
   {
     "name": "Jeremy Fiel",
@@ -354,6 +374,10 @@
         },
         "link": "https://landscape.json-schema.org/"
       }
-    ]
+    ],
+    "startedOn": {
+        "year": 2024,
+        "month": "September"
+    }
   }  
 ]


### PR DESCRIPTION
This PR resolves issue #836.
This pull request adds two new fields to the ambassador schema to enable tracking the date an ambassador started and the last time their status was reviewed. This will ensure compliance with the requirement to review ambassador statuses annually.

1. **Schema Updates:**
   - Added `startedOn` (Date): Tracks the date an individual became an ambassador.
   - Added `lastReviewedOn` (Date): Tracks the date the ambassador status was last reviewed.

2. **Data Population:**
   - Populated `startedOn` for existing ambassadors based on available historical data.

### Data Updates
- Retrieved start dates from existing records, verified by historical Slack messages (populated using the month and year when the ambassador was added to the channel).
- Populated the `startedOn` field for all current ambassadors.

### Code Changes
- Updated the ambassador model to include the new fields.
- Made startedOn date a required field.

## Verification
- Start dates were confirmed via Slack server history.

## Checklist
- [x] Schema updated with `startedOn` and `lastReviewedOn` fields.
- [x] Existing data populated with verified `startedOn` dates.
- [x] All changes included in a single PR.
- [x] Tested and verified changes.

---

@Relequestual : Please review the proposed schema changes and confirm that the populated data aligns with expectations. Any feedback or further suggestions are welcome!
