### PR TITLE
Remove additional gmail link

### DIFF
--- a/INFRASTRUCTURE.md
+++ b/INFRASTRUCTURE.md
@@ -48,7 +48,7 @@ The working location for these resources is in the specification repository at h
 We are capturing feedback in the website using a cloudflare worker to receive the data and send it to an Airtable database. The Airtable account is owned and paid for by Postman.
 
 ## The JSON Schema Calendar
-We are using a Google Calendar to share with the Community all the events. This Calendar has been created with a Google Account associated with the emails info@json-schema.org and json.schema.community@gmail.com.
+We are using a Google Calendar to share with the Community all the events. This Calendar has been created with a Google Account associated with the emails info@json-schema.org.
 
 ## Bots
 The Slack server has a number of bots which feed data into specific channels.


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
**GitHub Issue:**  Closes #860 

**Summary**:  As per @jdesrosiers https://github.com/json-schema-org/TSC/issues/10#issuecomment-2467318864,changed all calendar links to point to [info@json-schema.org](mailto:info@json-schema.org) and removed [json-schema-community@gmail.com](mailto:json-schema-community@gmail.com).

**Do you think resolving this issue might require an [Architectural Decision Record (ADR)](https://github.com/json-schema-org/community/blob/main/CONTRIBUTING.md#key-architectural-decisions)? (significant or noteworthy)**
<!-- If the issue has the `adr-required`, this PR must include an ADR. -->
<!-- If you do not want to include an ADR, or are not sure how to make one, make sure you allow edits to this PR by maintainers. -->

No
@benjagm , was this the expected change?