### PR TITLE
Adding website icon link to the schema and the instance

### DIFF
--- a/programs/ambassadors/ambassadors-schema.json
+++ b/programs/ambassadors/ambassadors-schema.json
@@ -39,6 +39,10 @@
         "type": "string",
         "description": "LinkedIn profile URL of the contributor"
       },
+      "website": {
+        "type": "string",
+        "description": "Full website URL of the contributor"
+      },
       "company": {
         "type": "string",
         "description": "Company where the contributor works"

--- a/programs/ambassadors/ambassadors-schema.json
+++ b/programs/ambassadors/ambassadors-schema.json
@@ -39,10 +39,6 @@
         "type": "string",
         "description": "LinkedIn profile URL of the contributor"
       },
-      "website": {
-        "type": "string",
-        "description": "A full URL to the contributor personal website"
-      },
       "company": {
         "type": "string",
         "description": "Company where the contributor works"

--- a/programs/ambassadors/ambassadors-schema.json
+++ b/programs/ambassadors/ambassadors-schema.json
@@ -39,6 +39,10 @@
         "type": "string",
         "description": "LinkedIn profile URL of the contributor"
       },
+      "website": {
+        "type": "string",
+        "description": "A full URL to the contributor personal website"
+      },
       "company": {
         "type": "string",
         "description": "Company where the contributor works"

--- a/programs/ambassadors/ambassadors.json
+++ b/programs/ambassadors/ambassadors.json
@@ -139,6 +139,7 @@
     "title": "Founder",
     "github": "jviotti",
     "linkedin": "jviotti",
+    "website": "https://www.jviotti.com",
     "company": "Sourcemeta",
     "country": "🇧🇴",
     "contributions": [

--- a/programs/ambassadors/ambassadors.json
+++ b/programs/ambassadors/ambassadors.json
@@ -139,7 +139,6 @@
     "title": "Founder",
     "github": "jviotti",
     "linkedin": "jviotti",
-    "website": "https://www.jviotti.com",
     "company": "Sourcemeta",
     "country": "🇧🇴",
     "contributions": [


### PR DESCRIPTION
### Summary:

This change will show @jviotti's website link as part of the other icon links.  
**Notice**: This will work only if [Adding 'website' to the Ambassador card format #1456](https://github.com/json-schema-org/website/pull/1456) is already merged.

![Screenshot 2025-03-04 171152](https://github.com/user-attachments/assets/e586f4e1-54a8-4cf1-9b99-23f4d0ab1bd8)


### Do you think resolving this issue might require an [Architectural Decision Record (ADR)](https://github.com/json-schema-org/community/blob/main/CONTRIBUTING.md#key-architectural-decisions)? (significant or noteworthy)

No

