### PR TITLE
Update ambassadors.json

### DIFF
--- a/programs/ambassadors/ambassadors.json
+++ b/programs/ambassadors/ambassadors.json
@@ -64,7 +64,7 @@
   {
     "name": "David Biesack",
     "img": "https://avatars.githubusercontent.com/u/545944?s=400&u=26818946106e2d8ae8c0cb5e0b72d6c7f612d268&v=4",
-    "bio": "Chief API Officer at APiture (I design banking APIs with OpenAPI 3.1, JSON Schema 2020/12) and author of the API Design Matters blog, https://apidesignmatters.substack.com/ ",
+    "bio": "Chief API Officer at APiture (I design banking APIs with OpenAPI 3.1, JSON Schema 2020/12) and author of the API Design Matters blog",
     "title": "Chief API Officer",
     "github": "DavidBiesack",
     "mastodon": "@DavidBiesack@fosstodon.org",
@@ -348,8 +348,8 @@
   {
     "name": "Jeremy Fiel",
     "img": "https://avatars.githubusercontent.com/u/32110157?v=4",
-    "bio": "Originally, an international logistics expert with more than 15 years of professional experience, Jeremy transitioned to software, specifically APIs, about 8 years ago. His passion for learning and contributing back to the community is where he found a love for open source projects. He is now a consistent contributor to projects such as [Redocly](https://github.com/redocly) and the [OpenAPI Initiative](https://github.com/OAI) projects, and a very active community member of JSON Schema.",
-    "title": "Principal Software Engineer | OpenAPI | JSON Schema | Arazzo | APIs",
+    "bio": "Originally, an international logistics expert with more than 15 years of professional experience, Jeremy transitioned to software, specifically APIs, about 8 years ago. His passion for learning and contributing back to the community is where he found a love for open source projects. He is now a consistent contributor to projects such as Redocly and the OpenAPI Initiative projects, and a very active community member of JSON Schema.",
+    "title": "Principal Software Engineer | OpenAPI | JSON Schema | Arazzo | APIs ",
     "github": "jeremyfiel",
     "twitter": "jeremyfiel",
     "linkedin": "jeremyfiel",


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
**GitHub Issue:** https://github.com/json-schema-org/website/issues/2165

**Summary**:

This PR cleans up `ambassadors.json` by removing inline Markdown links and plain URLs from ambassador bios and converting them to plain text.

### Changes Made
- Removed Markdown link syntax such as:
  - `[Redocly](https://github.com/redocly)`
  - `[OpenAPI Initiative](https://github.com/OAI)`
- Removed direct URL references such as:
  - `https://apidesignmatters.substack.com/`
- Updated bios to use clean plain text (e.g., "Redocly", "OpenAPI Initiative", "API Design Matters")

### Motivation

Previously, ambassador bios contained embedded Markdown links and raw URLs directly inside the JSON data. This mixed presentation concerns with content data.

With the introduction of the `parseBio` function in `AmbassadorsCard.tsx`, linking is now handled at the component level. The JSON file remains clean and presentation-agnostic, while the UI layer dynamically converts specific keywords into styled external links.

### Result

- Cleaner and more maintainable JSON data
- Proper separation of data and presentation
- Centralized link handling logic inside the React component
- No functional change to user-facing behavior

**Do you think resolving this issue might require an [Architectural Decision Record (ADR)](https://github.com/json-schema-org/community/blob/main/CONTRIBUTING.md#key-architectural-decisions)? (significant or noteworthy)**

No

[JUSTIFICATION]

This change is a small refactor and content cleanup that improves separation of concerns between data and presentation. It does not introduce a new architectural pattern, system-level decision, or long-term structural change. Therefore, an ADR is not required.