### PR TITLE
fix: correct sponsor anchor links for Gold, Silver, and Bronze tiers

### DIFF
--- a/programs/sponsors/sponsors.md
+++ b/programs/sponsors/sponsors.md
@@ -33,7 +33,7 @@ Community sponsors is a special tier for companies under 20 employees. Community
 
 Bronze sponsors donate $100 per month to the project, and get the following benefits:
 
-- Visibility on the front page of [https://json-schema.org](https://json-schema.org) in the "sponsors" section (about 110,000 views/month on November, 2023).
+- Visibility on the front page of [https://json-schema.org](https://json-schema.org/#bronze-sponsors) in the "sponsors" section (about 110,000 views/month on November, 2023).
 - Visibility on the GitHub main project page in the "sponsors" section.
 - "Thank you" tweet from [@jsonschema](https://twitter.com/jsonschema).
 - "Thank you" post in Linkedin from [@jsonschema](https://www.linkedin.com/company/jsonschema).
@@ -44,6 +44,7 @@ There is a limit to 10 silver sponsors.
 
 Silver sponsors donate $500 per month to the project, and get the following benefits:
 
+- Visibility on the front page of [https://json-schema.org](https://json-schema.org/#silver-sponsors) in the "sponsors" section.
 - Same benefits as bronze sponsors.
 - A mention on the Newsletter.
 - Possibility of getting expert advice from the team.
@@ -55,6 +56,7 @@ There is a limit to 3 gold sponsors.
 
 Gold sponsors donate $1,000 per month to the project, and get the following benefits:
 
+- Visibility on the front page of [https://json-schema.org](https://json-schema.org/#gold-sponsors) in the "sponsors" section.
 - Same benefits as silver sponsors.
 - Company logo in the footer of the Newsletter.
 - Company logo on all [https://json-schema.org](https://json-schema.org) page footers.


### PR DESCRIPTION
**GitHub Issue:** #2277     
Issue link :https://github.com/json-schema-org/website/issues/2277#issuecomment-3964276045


**Summary**:

This PR updates the sponsor section links in `sponsors.md` so they correctly point to the respective sponsor tier anchors on the JSON Schema website.

Previously, the links did not consistently navigate to the correct sponsor tier sections. This update ensures the links correctly reference the following anchors on the website:

* `#gold-sponsors`
* `#silver-sponsors`
* `#bronze-sponsors`

This complements the related fix implemented in the website repository to ensure navigation works correctly for all sponsor tiers.

Related PR in website repository: https://github.com/json-schema-org/website/pull/2320

**Do you think resolving this issue might require an Architectural Decision Record (ADR)?**

No

**JUSTIFICATION**

This change only updates documentation links in `sponsors.md` and does not introduce any architectural or structural changes to the project.
