### PR TITLE
Remove GitHub App token logging from ocwm-creator workflow

### DIFF
--- a/.github/workflows/ocwm-creator.yml
+++ b/.github/workflows/ocwm-creator.yml
@@ -94,7 +94,6 @@ jobs:
             auth: process.env.MY_TOKEN
           });
 
-          console.log("Token:" + process.env.MY_TOKEN);
           const ocwmnumber = ${{ steps.create-issue.outputs.issue-number }};
 
           const { data: ocwmissue } = await mygithub.request(`GET /repos/${context.repo.owner}/${context.repo.repo}/issues/${ ocwmnumber }`, {


### PR DESCRIPTION
## Summary

This PR removes the explicit logging of the GitHub App token from the `ocwm-creator` workflow.

## Changes

- Removed `console.log("Token:" + process.env.MY_TOKEN);`

Fixes #1032